### PR TITLE
use more general exception

### DIFF
--- a/config_utilities/src/string_utils.cpp
+++ b/config_utilities/src/string_utils.cpp
@@ -104,7 +104,7 @@ std::string scalarToString(const YAML::Node& data, bool reformat_float) {
   double value;
   try {
     value = data.as<double>();
-  } catch (const YAML::InvalidNode&) {
+  } catch (const std::exception&) {
     return orig.str();  // value is some sort of string that can't be parsed as a float
   }
 


### PR DESCRIPTION
@Schmluk turns out I was looking for the wrong exception here. I just used `std::exception` instead of trying to get the exact right exception, shouldn't really affect much