### PR TITLE
fix template default errors and other warnings

### DIFF
--- a/config_utilities/demos/demo_ros.cpp
+++ b/config_utilities/demos/demo_ros.cpp
@@ -108,6 +108,7 @@ void declare_config(SubConfig& config) {
 class Base {
  public:
   virtual void print() const = 0;
+  virtual ~Base() = default;
 };
 
 class DerivedA : public Base {

--- a/config_utilities/include/config_utilities/factory.h
+++ b/config_utilities/include/config_utilities/factory.h
@@ -203,7 +203,7 @@ struct ConfigWrapperImpl : public ConfigWrapper {
   explicit ConfigWrapperImpl(const std::string& _type) : ConfigWrapper(_type) {}
   ConfigT config;
   std::unique_ptr<ConfigWrapper> clone() const override { return std::make_unique<ConfigWrapperImpl<ConfigT>>(*this); };
-  void onDeclareConfig() { declare_config(config); }
+  void onDeclareConfig() override { declare_config(config); }
   std::unique_ptr<ConfigWrapper> createDefault() const override {
     return std::make_unique<ConfigWrapperImpl<ConfigT>>(type);
   };

--- a/config_utilities/include/config_utilities/internal/visitor_impl.hpp
+++ b/config_utilities/include/config_utilities/internal/visitor_impl.hpp
@@ -120,7 +120,7 @@ MetaData Visitor::subVisit(ConfigT& config,
 }
 
 // Visit a non-config field.
-template <typename T, typename std::enable_if<!isConfig<T>(), bool>::type = true>
+template <typename T, typename std::enable_if<!isConfig<T>(), bool>::type>
 void Visitor::visitField(T& field, const std::string& field_name, const std::string& unit) {
   Visitor& visitor = Visitor::instance();
   if (visitor.mode == Visitor::Mode::kSet) {
@@ -147,7 +147,7 @@ void Visitor::visitField(T& field, const std::string& field_name, const std::str
 }
 
 // Visits a non-config field with conversion.
-template <typename Conversion, typename T, typename std::enable_if<!isConfig<T>(), bool>::type = true>
+template <typename Conversion, typename T, typename std::enable_if<!isConfig<T>(), bool>::type>
 void Visitor::visitField(T& field, const std::string& field_name, const std::string& unit) {
   Visitor& visitor = Visitor::instance();
   if (visitor.mode == Visitor::Mode::kSet) {
@@ -188,7 +188,7 @@ void Visitor::visitField(T& field, const std::string& field_name, const std::str
 }
 
 // Visits a single subconfig field.
-template <typename ConfigT, typename std::enable_if<isConfig<ConfigT>(), bool>::type = true>
+template <typename ConfigT, typename std::enable_if<isConfig<ConfigT>(), bool>::type>
 void Visitor::visitField(ConfigT& config, const std::string& field_name, const std::string& name_space) {
   Visitor& visitor = Visitor::instance();
   if (visitor.mode == Visitor::Mode::kGetDefaults) {
@@ -208,7 +208,7 @@ void Visitor::visitField(ConfigT& config, const std::string& field_name, const s
 }
 
 // Visit a vector of subconfigs.
-template <typename ConfigT, typename std::enable_if<isConfig<ConfigT>(), bool>::type = true>
+template <typename ConfigT, typename std::enable_if<isConfig<ConfigT>(), bool>::type>
 void Visitor::visitField(std::vector<ConfigT>& config, const std::string& field_name, const std::string& /* unit */) {
   Visitor& visitor = Visitor::instance();
   if (visitor.mode == Visitor::Mode::kGetDefaults) {
@@ -278,7 +278,7 @@ void Visitor::visitBase(ConfigT& config) {
   }
 }
 
-template <typename ConfigT, typename std::enable_if<!is_virtual_config<ConfigT>::value, bool>::type = true>
+template <typename ConfigT, typename std::enable_if<!is_virtual_config<ConfigT>::value, bool>::type>
 MetaData Visitor::getDefaults(const ConfigT& config) {
   Visitor visitor(Mode::kGetDefaults);
   ConfigT default_config;
@@ -286,7 +286,7 @@ MetaData Visitor::getDefaults(const ConfigT& config) {
   return visitor.data;
 }
 
-template <typename ConfigT, typename std::enable_if<is_virtual_config<ConfigT>::value, bool>::type = true>
+template <typename ConfigT, typename std::enable_if<is_virtual_config<ConfigT>::value, bool>::type>
 MetaData Visitor::getDefaults(const ConfigT& config) {
   Visitor visitor(Mode::kGetDefaults);
   if (config.isSet()) {

--- a/config_utilities/include/config_utilities/parsing/yaml.h
+++ b/config_utilities/include/config_utilities/parsing/yaml.h
@@ -130,7 +130,7 @@ bool toYamlFile(const ConfigT& config, const std::string& file_name) {
   // TODO(lschmid): Here should probably be some verification of the output and of the target file to be created, as
   // well as extension handling. For now let ofstream handle it.
   std::ofstream fout(file_name);
-  fout << std::string(out.c_str);
+  fout << std::string(out.c_str());
   return true;
 }
 

--- a/config_utilities/test/tests/config_arrays.cpp
+++ b/config_utilities/test/tests/config_arrays.cpp
@@ -85,6 +85,7 @@ void declare_config(ConfigWithArrays& config) {
 class ProcessorBase {
  public:
   virtual void process(std::string& s) const = 0;
+  virtual ~ProcessorBase() = default;
 };
 
 class AddString : public ProcessorBase {

--- a/config_utilities/test/tests/virtual_config.cpp
+++ b/config_utilities/test/tests/virtual_config.cpp
@@ -49,6 +49,7 @@ namespace config::test {
 class Base2 {
  public:
   virtual std::string name() const = 0;
+  virtual ~Base2() = default;
 };
 
 class Derived2 : public Base2 {


### PR DESCRIPTION
@Schmluk switched to use clang for some testing I'm doing downstream and found out that redeclaring template defaults is a compiler error (and found some other warnings). Might be worth considering a clang-based github action workflow at some point