### PR TITLE
add more error information when parsing virtual configs and treat emp…

### DIFF
--- a/config_utilities/include/config_utilities/factory.h
+++ b/config_utilities/include/config_utilities/factory.h
@@ -119,13 +119,15 @@ struct ModuleMapBase {
       return false;
     }
     if (map.find(type) == map.end()) {
-      std::string module_list;
-      for (const auto& entry : map) {
-        module_list.append(entry.first + "', '");
+      if (!type.empty()) {
+        std::string module_list;
+        for (const auto& entry : map) {
+          module_list.append(entry.first + "', '");
+        }
+        module_list = module_list.substr(0, module_list.size() - 4);
+        Logger::logError("No module of type '" + type + "' registered to the factory for " + type_info +
+                         ". Registered are: '" + module_list + "'.");
       }
-      module_list = module_list.substr(0, module_list.size() - 4);
-      Logger::logError("No module of type '" + type + "' registered to the factory for " + type_info +
-                       ". Registered are: '" + module_list + "'.");
       return false;
     }
     return true;

--- a/config_utilities/include/config_utilities/virtual_config.h
+++ b/config_utilities/include/config_utilities/virtual_config.h
@@ -111,6 +111,8 @@ class VirtualConfig {
    */
   void setOptional(bool optional = true) { optional_ = optional; }
 
+  bool optional() const { return optional_; }
+
   /**
    * @brief Get the string-identifier-type of the config stored in the virtual config.
    */
@@ -166,6 +168,10 @@ void declare_config(VirtualConfig<BaseT>& config) {
                                           : internal::getType(*data, type);
     if (success) {
       config.config_ = internal::ConfigFactory<BaseT>::create(type);
+    } else if (!config.optional_) {
+      std::stringstream ss;
+      ss << "Could not get type for '" << internal::typeInfo<BaseT>() << "'";
+      internal::Logger::logError(ss.str());
     }
   }
 


### PR DESCRIPTION
…ty type differently

@Schmluk should be pretty quick, just adding a little bit more context when `getType` fails when parsing virtual configs and makes empty type strings not result in the list of possible modules