### PR TITLE
reformat module registry printing and add utest

### DIFF
--- a/config_utilities/test/include/config_utilities/test/utils.h
+++ b/config_utilities/test/include/config_utilities/test/utils.h
@@ -60,6 +60,8 @@ class TestLogger : public internal::Logger {
   int numMessages() const { return messages_.size(); }
   void clear() { messages_.clear(); }
   void print() const;
+  bool hasMessages() const { return !messages_.empty(); }
+  const std::string& lastMessage() const { return messages_.back().second; }
 
   static std::shared_ptr<TestLogger> create();
 

--- a/config_utilities/test/tests/factory.cpp
+++ b/config_utilities/test/tests/factory.cpp
@@ -200,6 +200,9 @@ TEST(Factory, moduleNameConflicts) {
 }
 
 TEST(Factory, printRegistryInfo) {
+  const auto registration1 = config::Registration<TemplatedBase<int>, TemplatedDerived<int, int>>("int_derived");
+  const auto registration2 =
+      config::Registration<TemplatedBase<float>, TemplatedDerived<float, float>>("float_derived");
   const std::string expected = R"""(Modules registered to factories: {
   config::internal::Formatter(): {
     'asl', 
@@ -217,14 +220,14 @@ TEST(Factory, printRegistryInfo) {
     'AddString', 
   },
   config::test::TemplatedBase<float>(): {
-    'name', 
+    'float_derived', 
   },
   config::test::TemplatedBase<int>(): {
-    'name', 
-    'other_name', 
+    'int_derived', 
   },
 })""";
   const std::string modules = internal::ModuleRegistry::getAllRegistered();
+  std::cout << modules << std::endl;
   EXPECT_EQ(modules, expected);
 }
 

--- a/config_utilities/test/tests/factory.cpp
+++ b/config_utilities/test/tests/factory.cpp
@@ -219,25 +219,25 @@ TEST(Factory, printRegistryInfo) {
       config::Registration<TemplatedBase<float>, TemplatedDerived<float, float>>("float_derived");
   const std::string expected = R"""(Modules registered to factories: {
   config::internal::Formatter(): {
-    'asl', 
+    'asl' (config::internal::AslFormatter),
   },
   config::test::Base(int): {
-    'DerivedA', 
-    'DerivedB', 
-    'DerivedC', 
-    'DerivedD', 
+    'DerivedA' (config::test::DerivedA),
+    'DerivedB' (config::test::DerivedB),
+    'DerivedC' (config::test::DerivedC),
+    'DerivedD' (config::test::DerivedD),
   },
   config::test::Base2(): {
-    'Derived2', 
+    'Derived2' (config::test::Derived2),
   },
   config::test::ProcessorBase(): {
-    'AddString', 
+    'AddString' (config::test::AddString),
   },
   config::test::TemplatedBase<float>(): {
-    'float_derived', 
+    'float_derived' (config::test::TemplatedDerived<float, float>),
   },
   config::test::TemplatedBase<int>(): {
-    'int_derived', 
+    'int_derived' (config::test::TemplatedDerived<int, int>),
   },
 })""";
   const std::string modules = internal::ModuleRegistry::getAllRegistered();


### PR DESCRIPTION
- Reformats printing of module registry to be ordered and grouped by module.
- Add utest to check printing and warning when registering.

@nathanhhughes Turns out the behavior was already as intended, but now I'm sure and the printing looks clearer (hopefully) 🙂 