### PR TITLE
Feature/assign virtual configs

### DIFF
--- a/config_utilities/include/config_utilities/factory.h
+++ b/config_utilities/include/config_utilities/factory.h
@@ -230,17 +230,25 @@ class ConfigTypeRegistry {
  public:
   static void setTypeName(const std::string& type) {
     // NOTE(lschmid): This is not forbidden behavior, but is not recommended so for now simply warn the user.
+    std::string& type_ = instance().type_;
     if (!type_.empty() && type_ != type) {
       Logger::logInfo("Overwriting type name for config '" + typeName<ConfigT>() + "' for base module '" +
-                      typeName<BaseT>() + "' from '" + type_ + "' to '" + type +
+                      typeName<BaseT>() + "' from '" + instance().type_ + "' to '" + type +
                       "'. Defining different type identifiers for the same derived module is not recommended.");
     }
     type_ = type;
   }
-  static std::string getType() { return type_; }
+  static std::string getType() { return instance().type_; }
 
  private:
-  inline static std::string type_;
+  static ConfigTypeRegistry& instance() {
+    static ConfigTypeRegistry instance_;
+    return instance_;
+  }
+
+  ConfigTypeRegistry() = default;
+
+  std::string type_;
 };
 
 // Definitions of the Factories.

--- a/config_utilities/include/config_utilities/factory.h
+++ b/config_utilities/include/config_utilities/factory.h
@@ -224,6 +224,25 @@ struct ConfigWrapperImpl : public ConfigWrapper {
   };
 };
 
+// Registry for config names based on derived types in the factory.
+template <typename BaseT, typename ConfigT>
+class ConfigTypeRegistry {
+ public:
+  static void setTypeName(const std::string& type) {
+    // NOTE(lschmid): This is not forbidden behavior, but is not recommended so for now simply warn the user.
+    if (!type_.empty() && type_ != type) {
+      Logger::logInfo("Overwriting type name for config '" + typeName<ConfigT>() + "' for base module '" +
+                      typeName<BaseT>() + "' from '" + type_ + "' to '" + type +
+                      "'. Defining different type identifiers for the same derived module is not recommended.");
+    }
+    type_ = type;
+  }
+  static std::string getType() { return type_; }
+
+ private:
+  inline static std::string type_;
+};
+
 // Definitions of the Factories.
 // Factory to create configs.
 template <class BaseT>
@@ -237,6 +256,9 @@ struct ConfigFactory {
     FactoryMethod method = [type]() { return new ConfigWrapperImpl<DerivedConfigT>(type); };
     // If the config is already registered, e.g. from different constructor args no warning needs to be printed.
     ModuleMap::addEntry(type, method, "");
+
+    // Register the type name for the config.
+    ConfigTypeRegistry<BaseT, DerivedConfigT>::setTypeName(type);
   }
 
   // Create the config.

--- a/config_utilities/include/config_utilities/virtual_config.h
+++ b/config_utilities/include/config_utilities/virtual_config.h
@@ -99,9 +99,9 @@ class VirtualConfig {
     const std::string type = internal::ConfigTypeRegistry<BaseT, ConfigT>::getType();
     if (type.empty()) {
       // No type defined for the config.
-      Logger::logError("No module for config '" + internal::typeInfo<ConfigT>() +
-                       "' is registered to the factory for '" + internal::typeInfo<BaseT>() +
-                       "' to set virtual config.");
+      internal::Logger::logError("No module for config '" + internal::typeName<ConfigT>() +
+                                 "' is registered to the factory for '" + internal::typeName<BaseT>() +
+                                 "' to set virtual config.");
       return false;
     }
 

--- a/config_utilities/test/tests/factory.cpp
+++ b/config_utilities/test/tests/factory.cpp
@@ -229,6 +229,7 @@ TEST(Factory, printRegistryInfo) {
   },
   config::test::Base2(): {
     'Derived2' (config::test::Derived2),
+    'Derived2A' (config::test::Derived2A),
   },
   config::test::ProcessorBase(): {
     'AddString' (config::test::AddString),


### PR DESCRIPTION
- Adds assignment operators and constructors for virtual configs and other config structs.
- Natural initialization does not require specifying the type manually.
- NOTE: The above may fail if the same config is registered with different names. For now this behavior is supported but will warn the user. Could consider enforcing this to avoid issues in the future.
- Add utest for new functionality

@nathanhhughes This will break compatibility with the {Config, name} initialization, but I don't think we should support manually specifying the name in the future.