### PR TITLE
add new method for accessing underlying config struct in virtual config

### DIFF
--- a/config_utilities/include/config_utilities/virtual_config.h
+++ b/config_utilities/include/config_utilities/virtual_config.h
@@ -146,6 +146,25 @@ class VirtualConfig {
   std::string getType() const { return config_ ? config_->type : "Uninitialized"; }
 
   /**
+   * @brief Get the underlying config that this holds, if set
+   * @tparam ConfigT Derived type of underlying config
+   * @returns Pointer to the underlying config if valid and the same type, nullptr otherwise
+   */
+  template <typename ConfigT>
+  const ConfigT* getUnderlying() const {
+    if (!config_) {
+      return nullptr;
+    }
+
+    auto derived_wrapper = dynamic_cast<const internal::ConfigWrapperImpl<ConfigT>*>(config_.get());
+    if (!derived_wrapper) {
+      return nullptr;
+    }
+
+    return &derived_wrapper->config;
+  }
+
+  /**
    * @brief Create the DerivedT object specified in the config.
    *
    * @tparam ConstructorArguments Type of ptional additional arguments to pass to the constructor of DerivedT.

--- a/config_utilities/test/tests/virtual_config.cpp
+++ b/config_utilities/test/tests/virtual_config.cpp
@@ -330,4 +330,22 @@ Warning: Check [3/3] failed for 'base_config.f': param >= 0 (is: '-1').
   EXPECT_EQ(msg, expected);
 }
 
+TEST(VirtualConfig, getUnderlying) {
+  Settings().restoreDefaults();
+
+  VirtualConfig<Base2> config;
+  EXPECT_FALSE(config.isSet());
+  EXPECT_FALSE(config.getUnderlying<Derived2>());
+
+  config = Derived2::Config();
+  EXPECT_TRUE(config.isSet());
+  EXPECT_FALSE(config.getUnderlying<Derived2A::Config>());
+  EXPECT_TRUE(config.getUnderlying<Derived2::Config>());
+
+  config = Derived2A::Config();
+  EXPECT_TRUE(config.isSet());
+  EXPECT_FALSE(config.getUnderlying<Derived2::Config>());
+  EXPECT_TRUE(config.getUnderlying<Derived2A::Config>());
+}
+
 }  // namespace config::test


### PR DESCRIPTION
@Schmluk not fully sure yet if this is the right design choice to fix the actual issue I'm having (which is maybe needing to remap or modify elements of a virtual config if it matches a known type), but curious if you have thoughts about whether or not this extra `VirtualConfig` method is appropriate