### PR TITLE
Feature/unset tracing

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -57,4 +57,4 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{env.BUILD_TYPE}}
+      run: ctest -C ${{env.BUILD_TYPE}} --rerun-failed --output-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ CATKIN_IGNORE
 # Local utilities
 Notes.txt
 tmp/
+
+compile_commands.json

--- a/config_utilities/include/config_utilities/formatting/asl.h
+++ b/config_utilities/include/config_utilities/formatting/asl.h
@@ -56,6 +56,7 @@ class AslFormatter : public Formatter {
 
  protected:
   std::string formatErrorsImpl(const MetaData& data, const std::string& what, const Severity severity) override;
+  std::string formatMissingImpl(const MetaData& data, const std::string& what, const Severity severity) override;
   std::string formatConfigImpl(const MetaData& data) override;
   std::string formatConfigsImpl(const std::vector<MetaData>& data) override;
 
@@ -70,6 +71,7 @@ class AslFormatter : public Formatter {
 
   // Helper functions.
   std::string formatErrorsRecursive(const MetaData& data, const std::string& sev, const size_t length);
+  std::string formatMissingRecursive(const MetaData& data, const std::string& sev, const size_t length);
   std::string formatChecksInternal(const MetaData& data, const std::string& sev, const size_t length);
   std::string formatErrorsInternal(const MetaData& data, const std::string& sev, const size_t length);
   std::string toStringInternal(const MetaData& data, size_t indent) const;

--- a/config_utilities/include/config_utilities/internal/formatter.h
+++ b/config_utilities/include/config_utilities/internal/formatter.h
@@ -63,6 +63,11 @@ class Formatter {
                                   const std::string& what = "",
                                   const Severity severity = Severity::kWarning);
 
+  // Format all missing fields in the meta data into the display string.
+  static std::string formatMissing(const MetaData& data,
+                                   const std::string& what = "",
+                                   const Severity severity = Severity::kWarning);
+
   // Format the content of a single config the display string.
   static std::string formatConfig(const MetaData& data);
 
@@ -74,10 +79,12 @@ class Formatter {
 
  protected:
   virtual std::string formatErrorsImpl(const MetaData& data, const std::string& what, const Severity severity);
+  virtual std::string formatMissingImpl(const MetaData& data, const std::string& what, const Severity severity);
   virtual std::string formatConfigImpl(const MetaData& data);
   virtual std::string formatConfigsImpl(const std::vector<MetaData>& data);
 
  private:
+  std::string getUnspecifiedString() const;
   inline static Formatter::Ptr formatter_ = std::make_shared<Formatter>();
 };
 

--- a/config_utilities/include/config_utilities/internal/meta_data.h
+++ b/config_utilities/include/config_utilities/internal/meta_data.h
@@ -63,6 +63,9 @@ struct FieldInfo {
 
   // Whether the field corresponds to its default value. Only queried if Settings().indicate_default_values is true.
   bool is_default = false;
+
+  // Whether or not the field was parsed
+  bool was_parsed = false;
 };
 
 // Struct to issue warnings. Currently used for parsing errors but can be extended to other warnings in the future.
@@ -126,6 +129,9 @@ struct MetaData {
 
   // Utility to look up if there's any error messages in the data or its sub-configs.
   bool hasErrors() const;
+
+  // Utility to look up if any fields were not parsed
+  bool hasMissing() const;
 
   // Utility function so not every class needs to write their own recursion.
   void performOnAll(const std::function<void(MetaData&)>& func);

--- a/config_utilities/include/config_utilities/internal/visitor.h
+++ b/config_utilities/include/config_utilities/internal/visitor.h
@@ -64,7 +64,6 @@ struct Visitor {
   static MetaData setValues(ConfigT& config,
                             const YAML::Node& node,
                             const bool print_warnings = true,
-                            const bool print_missing = false,
                             const std::string& name_space = "",
                             const std::string& field_name = "");
 

--- a/config_utilities/include/config_utilities/internal/visitor.h
+++ b/config_utilities/include/config_utilities/internal/visitor.h
@@ -64,6 +64,7 @@ struct Visitor {
   static MetaData setValues(ConfigT& config,
                             const YAML::Node& node,
                             const bool print_warnings = true,
+                            const bool print_missing = false,
                             const std::string& name_space = "",
                             const std::string& field_name = "");
 

--- a/config_utilities/include/config_utilities/internal/visitor.h
+++ b/config_utilities/include/config_utilities/internal/visitor.h
@@ -65,7 +65,8 @@ struct Visitor {
                             const YAML::Node& node,
                             const bool print_warnings = true,
                             const std::string& name_space = "",
-                            const std::string& field_name = "");
+                            const std::string& field_name = "",
+                            const bool print_missing = true);
 
   // Get the data stored in the config.
   template <typename ConfigT>

--- a/config_utilities/include/config_utilities/internal/visitor_impl.hpp
+++ b/config_utilities/include/config_utilities/internal/visitor_impl.hpp
@@ -60,7 +60,8 @@ MetaData Visitor::setValues(ConfigT& config,
                             const YAML::Node& node,
                             const bool print_warnings,
                             const std::string& name_space,
-                            const std::string& field_name) {
+                            const std::string& field_name,
+                            const bool print_missing) {
   Visitor visitor(Mode::kSet, name_space, field_name);
   visitor.data.data.reset(node);
   ::config::declare_config(config);
@@ -68,7 +69,7 @@ MetaData Visitor::setValues(ConfigT& config,
     Logger::logWarning(Formatter::formatErrors(visitor.data, "Errors parsing config", Severity::kWarning));
   }
 
-  if (Settings::instance().print_missing && visitor.data.hasMissing()) {
+  if (print_missing && Settings::instance().print_missing && visitor.data.hasMissing()) {
     Logger::logWarning(Formatter::formatMissing(visitor.data, "Missing fields from config", Severity::kWarning));
   }
 
@@ -115,7 +116,7 @@ MetaData Visitor::subVisit(ConfigT& config,
       data = getValues(config, print_warnings, name_space, field_name);
       break;
     case Visitor::Mode::kSet:
-      data = setValues(config, current_visitor.data.data, print_warnings, name_space, field_name);
+      data = setValues(config, current_visitor.data.data, print_warnings, name_space, field_name, false);
       break;
     case Visitor::Mode::kCheck:
       data = getChecks(config, field_name);
@@ -238,7 +239,7 @@ void Visitor::visitField(std::vector<ConfigT>& config, const std::string& field_
     size_t index = 0;
     for (const auto& node : nodes) {
       ConfigT& sub_config = config.emplace_back();
-      visitor.data.sub_configs.emplace_back(setValues(sub_config, node, false, "", field_name));
+      visitor.data.sub_configs.emplace_back(setValues(sub_config, node, false, "", field_name, false));
       visitor.data.sub_configs.back().array_config_index = index++;
     }
   }
@@ -282,7 +283,7 @@ void Visitor::visitField(std::map<K, ConfigT>& config, const std::string& field_
     for (auto&& [key, node] : nodes) {
       auto iter = config.emplace(YAML::Node(key).template as<K>(), ConfigT()).first;
       auto& sub_config = iter->second;
-      visitor.data.sub_configs.emplace_back(setValues(sub_config, node, false, "", field_name));
+      visitor.data.sub_configs.emplace_back(setValues(sub_config, node, false, "", field_name, false));
       visitor.data.sub_configs.back().map_config_key = key;
     }
   }

--- a/config_utilities/include/config_utilities/parsing/yaml.h
+++ b/config_utilities/include/config_utilities/parsing/yaml.h
@@ -62,8 +62,7 @@ namespace config {
 template <typename ConfigT>
 ConfigT fromYaml(const YAML::Node& node, const std::string& name_space = "") {
   ConfigT config;
-  const auto& settings = internal::Settings::instance();
-  internal::Visitor::setValues(config, internal::lookupNamespace(node, name_space), true, settings.print_missing);
+  internal::Visitor::setValues(config, internal::lookupNamespace(node, name_space), true);
   return config;
 }
 

--- a/config_utilities/include/config_utilities/parsing/yaml.h
+++ b/config_utilities/include/config_utilities/parsing/yaml.h
@@ -62,7 +62,8 @@ namespace config {
 template <typename ConfigT>
 ConfigT fromYaml(const YAML::Node& node, const std::string& name_space = "") {
   ConfigT config;
-  internal::Visitor::setValues(config, internal::lookupNamespace(node, name_space));
+  const auto& settings = internal::Settings::instance();
+  internal::Visitor::setValues(config, internal::lookupNamespace(node, name_space), true, settings.print_missing);
   return config;
 }
 
@@ -200,9 +201,9 @@ std::unique_ptr<BaseT> createFromYamlFileWithNamespace(const std::string& file_n
  * @brief Update the config with the values in a YAML node.
  * @note This function will update the field and check the validity of the config afterwards. If the config is invalid,
  * the field will be reset to its original value.
-  * @param config The config to update.
-  * @param node The node containing the field(s) to update.
-  * @param name_space Optionally specify a name space to create the config from. Separate names with slashes '/'.
+ * @param config The config to update.
+ * @param node The node containing the field(s) to update.
+ * @param name_space Optionally specify a name space to create the config from. Separate names with slashes '/'.
  */
 template <typename ConfigT>
 bool updateFromYaml(ConfigT& config, const YAML::Node& node, const std::string& name_space = "") {

--- a/config_utilities/include/config_utilities/settings.h
+++ b/config_utilities/include/config_utilities/settings.h
@@ -75,6 +75,9 @@ struct Settings {
   // If true, attempts to print floats and float-like fields with default stream precision
   bool reformat_floats = true;
 
+  // If true, prints fields that had no value present when being parsed
+  bool print_missing = false;
+
   /* Factory settings */
   // The factory will look for this param to deduce the type of the object to be created.
   std::string factory_type_param_name = "type";

--- a/config_utilities/src/asl_formatter.cpp
+++ b/config_utilities/src/asl_formatter.cpp
@@ -94,6 +94,64 @@ std::string AslFormatter::formatErrorsRecursive(const MetaData& data, const std:
   return result;
 }
 
+std::string AslFormatter::formatMissingImpl(const MetaData& data, const std::string& what, const Severity severity) {
+  const std::string sev = severityToString(severity) + ": ";
+  const size_t print_width = Settings::instance().print_width;
+  is_first_divider_ = true;
+  name_prefix_ = "";
+
+  // Header line.
+  std::string result = what + " '" + resolveConfigName(data) + "':\n" +
+                       internal::printCenter(resolveConfigName(data), print_width, '=') + "\n";
+
+  // Format all checks and errors.
+  result += formatErrorsRecursive(data, sev, print_width);
+  return result + std::string(print_width, '=');
+}
+
+std::string AslFormatter::formatMissingRecursive(const MetaData& data, const std::string& sev, const size_t length) {
+  const std::string name_prefix_before = name_prefix_;
+  if (Settings::instance().inline_subconfig_field_names) {
+    if (!data.field_name.empty()) {
+      // TOOD(nathan) refactor to put in metadata
+      name_prefix_ += data.field_name;
+      if (data.array_config_index >= 0) {
+        name_prefix_ += "[" + std::to_string(data.array_config_index) + "]";
+      } else if (data.map_config_key) {
+        name_prefix_ += "[" + *data.map_config_key + "]";
+      }
+      name_prefix_ += ".";
+    }
+  }
+
+  std::string result;
+  for (const auto& field_info : data.field_infos) {
+    if (field_info.was_parsed) {
+      continue;
+    }
+
+    const std::string rendered_name = "'" + name_prefix_ + field_info.name + "'";
+    const auto msg = sev + "Missing field" + rendered_name + "!";
+    result.append(wrapString(msg, length, sev.length(), false) + "\n");
+  }
+
+  // Add more dividers if necessary.
+  if (!Settings::instance().inline_subconfig_field_names && !result.empty()) {
+    if (is_first_divider_) {
+      is_first_divider_ = false;
+    } else {
+      result = internal::printCenter(resolveConfigName(data), Settings::instance().print_width, '-') + "\n" + result;
+    }
+  }
+
+  for (const auto& sub_data : data.sub_configs) {
+    result += formatMissingRecursive(sub_data, sev, length);
+  }
+
+  name_prefix_ = name_prefix_before;
+  return result;
+}
+
 std::string AslFormatter::formatChecksInternal(const MetaData& data, const std::string& sev, const size_t length) {
   std::string result;
   for (const auto& check : data.checks) {

--- a/config_utilities/src/asl_formatter.cpp
+++ b/config_utilities/src/asl_formatter.cpp
@@ -145,6 +145,7 @@ std::string AslFormatter::formatMissingRecursive(const MetaData& data, const std
   }
 
   for (const auto& sub_data : data.sub_configs) {
+    // TODO(nathan) think about indenting and actually showing subconfig structure
     result += formatMissingRecursive(sub_data, sev, length);
   }
 

--- a/config_utilities/src/asl_formatter.cpp
+++ b/config_utilities/src/asl_formatter.cpp
@@ -105,7 +105,7 @@ std::string AslFormatter::formatMissingImpl(const MetaData& data, const std::str
                        internal::printCenter(resolveConfigName(data), print_width, '=') + "\n";
 
   // Format all checks and errors.
-  result += formatErrorsRecursive(data, sev, print_width);
+  result += formatMissingRecursive(data, sev, print_width);
   return result + std::string(print_width, '=');
 }
 
@@ -131,7 +131,7 @@ std::string AslFormatter::formatMissingRecursive(const MetaData& data, const std
     }
 
     const std::string rendered_name = "'" + name_prefix_ + field_info.name + "'";
-    const auto msg = sev + "Missing field" + rendered_name + "!";
+    const auto msg = sev + "Missing field " + rendered_name + "!";
     result.append(wrapString(msg, length, sev.length(), false) + "\n");
   }
 

--- a/config_utilities/src/formatter.cpp
+++ b/config_utilities/src/formatter.cpp
@@ -41,6 +41,10 @@ std::string Formatter::formatErrors(const MetaData& data, const std::string& wha
   return formatter_->formatErrorsImpl(data, what, severity);
 }
 
+std::string Formatter::formatMissing(const MetaData& data, const std::string& what, const Severity severity) {
+  return formatter_->formatMissingImpl(data, what, severity);
+}
+
 std::string Formatter::formatConfig(const MetaData& data) { return formatter_->formatConfigImpl(data); }
 
 std::string Formatter::formatConfigs(const std::vector<MetaData>& data) { return formatter_->formatConfigsImpl(data); }
@@ -52,14 +56,18 @@ void Formatter::setFormatter(Formatter::Ptr formatter) {
 }
 
 std::string Formatter::formatErrorsImpl(const MetaData& data, const std::string& what, const Severity severity) {
-  return "No format specified. Specify a format by including one of 'config_utilities/formatters/<preferred_style>.h'.";
+  return getUnspecifiedString();
 }
 
-std::string Formatter::formatConfigImpl(const MetaData& data) {
-  return "No format specified. Specify a format by including one of 'config_utilities/formatters/<preferred_style>.h'.";
+std::string Formatter::formatMissingImpl(const MetaData& data, const std::string& what, const Severity severity) {
+  return getUnspecifiedString();
 }
 
-std::string Formatter::formatConfigsImpl(const std::vector<MetaData>& data) {
+std::string Formatter::formatConfigImpl(const MetaData& data) { return getUnspecifiedString(); }
+
+std::string Formatter::formatConfigsImpl(const std::vector<MetaData>& data) { return getUnspecifiedString(); }
+
+std::string Formatter::getUnspecifiedString() const {
   return "No format specified. Specify a format by including one of 'config_utilities/formatters/<preferred_style>.h'.";
 }
 

--- a/config_utilities/src/meta_data.cpp
+++ b/config_utilities/src/meta_data.cpp
@@ -41,11 +41,29 @@ bool MetaData::hasErrors() const {
   if (!errors.empty()) {
     return true;
   }
-  for (const MetaData& sub_config : sub_configs) {
+  for (const auto& sub_config : sub_configs) {
     if (sub_config.hasErrors()) {
       return true;
     }
   }
+  return false;
+}
+
+bool MetaData::hasMissing() const {
+  // first check all current fields
+  for (const auto& field_info : field_infos) {
+    if (!field_info.was_parsed) {
+      return true;
+    }
+  }
+
+  // next check all subconfigs recursively
+  for (const auto& sub_config : sub_configs) {
+    if (sub_config.hasMissing()) {
+      return true;
+    }
+  }
+
   return false;
 }
 

--- a/config_utilities/test/CMakeLists.txt
+++ b/config_utilities/test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(
   tests/enums.cpp
   tests/factory.cpp
   tests/inheritance.cpp
+  tests/missing_fields.cpp
   tests/namespacing.cpp
   tests/path.cpp
   tests/string_utils.cpp

--- a/config_utilities/test/tests/factory.cpp
+++ b/config_utilities/test/tests/factory.cpp
@@ -211,12 +211,11 @@ TEST(Factory, moduleNameConflicts) {
       config::Registration<TemplatedBase<float>, TemplatedDerived<float, float>, bool>("different_name");
   EXPECT_EQ(logger->numMessages(), 2);
 
-  std::cout << internal::ModuleRegistry::getAllRegistered() << std::endl;
-}
-
-TEST(Factory, printRegistryInfo) {
-  const auto registration1 = config::Registration<TemplatedBase<int>, TemplatedDerived<int, int>>("int_derived");
-  const auto registration2 =
+  // NOTE(nathan): combining printing and name conflicts tests to avoid different behaviors between clang and gcc (and
+  // local usage vs ctest). Otherwise sometimes the modules from moduleNameConflicts would get compiled into the
+  // registry and sometimes they wouldn't which would lead to inconsistent test behavior...
+  const auto registration8 = config::Registration<TemplatedBase<int>, TemplatedDerived<int, int>>("int_derived");
+  const auto registration9 =
       config::Registration<TemplatedBase<float>, TemplatedDerived<float, float>>("float_derived");
   const std::string expected = R"""(Modules registered to factories: {
   config::internal::Formatter(): {

--- a/config_utilities/test/tests/factory.cpp
+++ b/config_utilities/test/tests/factory.cpp
@@ -38,6 +38,7 @@
 #include <gtest/gtest.h>
 
 #include "config_utilities/config.h"
+#include "config_utilities/logging/log_to_stdout.h"
 #include "config_utilities/parsing/yaml.h"
 #include "config_utilities/test/utils.h"
 #include "config_utilities/traits.h"
@@ -221,6 +222,9 @@ TEST(Factory, printRegistryInfo) {
   config::internal::Formatter(): {
     'asl' (config::internal::AslFormatter),
   },
+  config::internal::Logger(): {
+    'stdout' (config::internal::StdoutLogger),
+  },
   config::test::Base(int): {
     'DerivedA' (config::test::DerivedA),
     'DerivedB' (config::test::DerivedB),
@@ -236,9 +240,18 @@ TEST(Factory, printRegistryInfo) {
   },
   config::test::TemplatedBase<float>(): {
     'float_derived' (config::test::TemplatedDerived<float, float>),
+    'name' (config::test::TemplatedDerived<float, float>),
+  },
+  config::test::TemplatedBase<float>(bool): {
+    'different_name' (config::test::TemplatedDerived<float, float>),
   },
   config::test::TemplatedBase<int>(): {
     'int_derived' (config::test::TemplatedDerived<int, int>),
+    'name' (config::test::TemplatedDerived<int, int>),
+    'other_name' (config::test::TemplatedDerived<int, int>),
+  },
+  config::test::TemplatedBase<int>(bool): {
+    'name' (config::test::TemplatedDerived<int, int>),
   },
 })""";
   const std::string modules = internal::ModuleRegistry::getAllRegistered();

--- a/config_utilities/test/tests/missing_fields.cpp
+++ b/config_utilities/test/tests/missing_fields.cpp
@@ -1,0 +1,78 @@
+/** -----------------------------------------------------------------------------
+ * Copyright (c) 2023 Massachusetts Institute of Technology.
+ * All Rights Reserved.
+ *
+ * AUTHORS:     Lukas Schmid <lschmid@mit.edu>, Nathan Hughes <na26933@mit.edu>
+ * AFFILIATION: MIT-SPARK Lab, Massachusetts Institute of Technology
+ * YEAR:        2023
+ * LICENSE:     BSD 3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * -------------------------------------------------------------------------- */
+
+#include <gtest/gtest.h>
+
+#include "config_utilities/config.h"
+#include "config_utilities/config_utilities.h"
+#include "config_utilities/parsing/yaml.h"
+
+namespace config::test {
+
+struct MissingSettingsGuard {
+  MissingSettingsGuard() { Settings().print_missing = true; }
+
+  ~MissingSettingsGuard() { Settings().restoreDefaults(); }
+};
+
+struct SimpleConfig {
+  double a = 1.0;
+  int b = 2;
+  std::string c = "3";
+};
+
+void declare_config(SimpleConfig& config) {
+  name("SimpleConfig");
+  field(config.a, "a");
+  field(config.b, "b");
+  field(config.c, "c");
+}
+
+bool operator==(const SimpleConfig& lhs, const SimpleConfig& rhs) {
+  return lhs.a == rhs.a && lhs.b == rhs.b && lhs.c == rhs.c;
+}
+
+void PrintTo(const SimpleConfig& config, std::ostream* os) { *os << toString(config); }
+
+TEST(MissingFields, ParseMissing) {
+  MissingSettingsGuard guard;
+  const std::string contents = "{a: 2.0, b: 3}";
+  const auto node = YAML::Load(contents);
+  const auto result = config::fromYaml<SimpleConfig>(node);
+  SimpleConfig expected{2.0, 3, "3"};
+  EXPECT_EQ(expected, result);
+}
+
+}  // namespace config::test


### PR DESCRIPTION
@Schmluk Not the prettiest formatting-wise, but I thought it was useful to add a mode for reporting what config fields were not parsed (which is slightly different than "set to the default") given some recent issues with setting configs. It's off by default and controlled globally via the settings struct. I tried to also have an arg to `setValues` to individually turn it on or off, but there's not any good way to pass that to the object factories when using virtual configs / create.