### PR TITLE
Fix/collection defaults

### DIFF
--- a/config_utilities/test/tests/config_arrays.cpp
+++ b/config_utilities/test/tests/config_arrays.cpp
@@ -143,6 +143,8 @@ bool operator==(const ConfigWithDefaultArray& lhs, const ConfigWithDefaultArray&
   return lhs.configs == rhs.configs;
 }
 
+void PrintTo(const ConfigWithDefaultArray& config, std::ostream* os) { *os << toString(config); }
+
 TEST(ConfigArrays, FromYamlSeq) {
   const std::string yaml_seq = R"(
 - s: "a"

--- a/config_utilities/test/tests/config_arrays.cpp
+++ b/config_utilities/test/tests/config_arrays.cpp
@@ -143,15 +143,6 @@ bool operator==(const ConfigWithDefaultArray& lhs, const ConfigWithDefaultArray&
   return lhs.configs == rhs.configs;
 }
 
-struct NestedConfigWithDefaultArray {
-  ConfigWithDefaultArray nested;
-};
-
-void declare_config(NestedConfigWithDefaultArray& config) {
-  name("NestedConfigWithDefaultArray");
-  field(config.nested, "nested");
-}
-
 TEST(ConfigArrays, FromYamlSeq) {
   const std::string yaml_seq = R"(
 - s: "a"
@@ -445,30 +436,6 @@ TEST(ConfigArrays, ArrayWithDefaults) {
     EXPECT_EQ(config.configs.size(), 0);
     ConfigWithDefaultArray expected{{}};
     EXPECT_EQ(config, expected);
-  }
-}
-
-TEST(ConfigArrays, ArrayWithDefaultsDefaultMark) {
-  {  // make sure not specifying anything results in default
-    const NestedConfigWithDefaultArray config_array;
-    const auto result = toString(config_array);
-    const auto expected = R"(========================= NestedConfigWithDefaultArray =========================
-nested [ConfigWithDefaultArray] (default):
-   configs[0] [AddString]:
-      s:                      world!
-   configs[1] [AddString]:
-      s:                      hello
-================================================================================)";
-    EXPECT_EQ(result, expected);
-  }
-
-  {  // make sure an empty config is not marked as default
-    const NestedConfigWithDefaultArray config_array{{{}}};
-    const auto result = toString(config_array);
-    const auto expected = R"(========================= NestedConfigWithDefaultArray =========================
-nested [ConfigWithDefaultArray]:
-================================================================================)";
-    EXPECT_EQ(result, expected);
   }
 }
 

--- a/config_utilities/test/tests/config_arrays.cpp
+++ b/config_utilities/test/tests/config_arrays.cpp
@@ -105,6 +105,8 @@ class AddString : public ProcessorBase {
       config::RegistrationWithConfig<ProcessorBase, AddString, AddString::Config>("AddString");
 };
 
+bool operator==(const AddString::Config& lhs, const AddString::Config& rhs) { return lhs.s == rhs.s; }
+
 void declare_config(AddString::Config& config) {
   name("AddString");
   field(config.s, "s");
@@ -125,6 +127,28 @@ struct ConfigWithNestedArray {
 
 void declare_config(ConfigWithNestedArray& config) {
   name("ConfigWithNextedArrays");
+  field(config.nested, "nested");
+}
+
+struct ConfigWithDefaultArray {
+  std::vector<AddString::Config> configs{{"world!"}, {"hello"}};
+};
+
+void declare_config(ConfigWithDefaultArray& config) {
+  name("ConfigWithDefaultArray");
+  field(config.configs, "configs");
+}
+
+bool operator==(const ConfigWithDefaultArray& lhs, const ConfigWithDefaultArray& rhs) {
+  return lhs.configs == rhs.configs;
+}
+
+struct NestedConfigWithDefaultArray {
+  ConfigWithDefaultArray nested;
+};
+
+void declare_config(NestedConfigWithDefaultArray& config) {
+  name("NestedConfigWithDefaultArray");
   field(config.nested, "nested");
 }
 
@@ -405,6 +429,47 @@ config_array[2] [ArrConfig]:
    f:               3
 ================================================================================)";
   EXPECT_EQ(formatted, expected);
+}
+
+TEST(ConfigArrays, ArrayWithDefaults) {
+  {  // make sure not specifying anything results in default
+    const auto node = YAML::Load("");
+    auto config = fromYaml<ConfigWithDefaultArray>(node);
+    EXPECT_EQ(config.configs.size(), 2);
+    EXPECT_EQ(config, ConfigWithDefaultArray());
+  }
+
+  {  // specifying empty list clears default
+    const auto node = YAML::Load("configs: []");
+    auto config = fromYaml<ConfigWithDefaultArray>(node);
+    EXPECT_EQ(config.configs.size(), 0);
+    ConfigWithDefaultArray expected{{}};
+    EXPECT_EQ(config, expected);
+  }
+}
+
+TEST(ConfigArrays, ArrayWithDefaultsDefaultMark) {
+  {  // make sure not specifying anything results in default
+    const NestedConfigWithDefaultArray config_array;
+    const auto result = toString(config_array);
+    const auto expected = R"(========================= NestedConfigWithDefaultArray =========================
+nested [ConfigWithDefaultArray] (default):
+   configs[0] [AddString]:
+      s:                      world!
+   configs[1] [AddString]:
+      s:                      hello
+================================================================================)";
+    EXPECT_EQ(result, expected);
+  }
+
+  {  // make sure an empty config is not marked as default
+    const NestedConfigWithDefaultArray config_array{{{}}};
+    const auto result = toString(config_array);
+    const auto expected = R"(========================= NestedConfigWithDefaultArray =========================
+nested [ConfigWithDefaultArray]:
+================================================================================)";
+    EXPECT_EQ(result, expected);
+  }
 }
 
 }  // namespace config::test

--- a/config_utilities/test/tests/config_maps.cpp
+++ b/config_utilities/test/tests/config_maps.cpp
@@ -99,6 +99,17 @@ void declare_config(ConfigWithNestedMaps& config) {
   field(config.nested, "nested");
 }
 
+struct ConfigWithDefaultMap {
+  std::map<std::string, MapConfig> configs{{"name1", {"world!", 1}}, {"name2", {"hello", 3}}};
+};
+
+void declare_config(ConfigWithDefaultMap& config) {
+  name("ConfigWithDefaultMap");
+  field(config.configs, "configs");
+}
+
+bool operator==(const ConfigWithDefaultMap& lhs, const ConfigWithDefaultMap& rhs) { return lhs.configs == rhs.configs; }
+
 TEST(ConfigMaps, FromYamlMap) {
   const std::string yaml_map = R"(
 x:
@@ -276,6 +287,23 @@ config_map[4] [MapConfig]:
    f:               3
 ================================================================================)";
   EXPECT_EQ(formatted, expected);
+}
+
+TEST(ConfigMaps, MapWithDefault) {
+  {  // make sure not specifying anything results in default
+    const auto node = YAML::Load("");
+    auto config = fromYaml<ConfigWithDefaultMap>(node);
+    EXPECT_EQ(config.configs.size(), 2);
+    EXPECT_EQ(config, ConfigWithDefaultMap());
+  }
+
+  {  // specifying empty list clears default
+    const auto node = YAML::Load("configs: {}");
+    auto config = fromYaml<ConfigWithDefaultMap>(node);
+    EXPECT_EQ(config.configs.size(), 0);
+    ConfigWithDefaultMap expected{{}};
+    EXPECT_EQ(config, expected);
+  }
 }
 
 }  // namespace config::test

--- a/config_utilities/test/tests/config_maps.cpp
+++ b/config_utilities/test/tests/config_maps.cpp
@@ -110,6 +110,8 @@ void declare_config(ConfigWithDefaultMap& config) {
 
 bool operator==(const ConfigWithDefaultMap& lhs, const ConfigWithDefaultMap& rhs) { return lhs.configs == rhs.configs; }
 
+void PrintTo(const ConfigWithDefaultMap& config, std::ostream* os) { *os << toString(config); }
+
 TEST(ConfigMaps, FromYamlMap) {
   const std::string yaml_map = R"(
 x:


### PR DESCRIPTION
@Schmluk not sure if I messed this up when doing ordered maps, but the previous behavior for parsing collections (i.e., vectors and maps) didn't allow for default non-empty collections. I think this is the better behavior: use the default empty or non-empty collection if the yaml field isn't populated, and otherwise clear and override it