### PR TITLE
add cli api for already parsed args

### DIFF
--- a/config_utilities/src/commandline.cpp
+++ b/config_utilities/src/commandline.cpp
@@ -229,4 +229,14 @@ YAML::Node loadFromArguments(int& argc, char* argv[], bool remove_args) {
   return node;
 }
 
+YAML::Node loadFromArguments(const std::vector<std::string>& _args) {
+  std::vector<std::string> args(_args.begin(), _args.end());
+
+  int argc = args.size();
+  std::vector<char*> argv;
+  std::transform(args.begin(), args.end(), std::back_inserter(argv), [](auto& m) { return m.data(); });
+  // no need to remove arguments given that the original vector won't be modified
+  return loadFromArguments(argc, argv.data(), false);
+}
+
 }  // namespace config::internal


### PR DESCRIPTION
Adds an alternative API for parsing command line arguments from a vector of strings (which is the only way to get access to the command line arguments in some cases in ROS2). I decided to punt on adding the same API for `Context` because I didn't want to figure out how to make it threadsafe yet