### PR TITLE
fix: make factory functions use std::move instead of std::forward

### DIFF
--- a/config_utilities/include/config_utilities/factory.h
+++ b/config_utilities/include/config_utilities/factory.h
@@ -243,7 +243,7 @@ class ModuleRegistry {
 
     // wrap factory call to register any allocations
     return [factory, key, type, create_callback](Args... args) -> BaseT* {
-      auto pointer = factory(args...);
+      auto pointer = factory(std::move(args)...);
       create_callback(key, type, pointer);
       return pointer;
     };
@@ -367,7 +367,7 @@ struct ObjectFactory {
   // Add entries.
   template <typename DerivedT>
   static void addEntry(const std::string& type) {
-    const Constructor method = [](Args... args) -> BaseT* { return new DerivedT(args...); };
+    const Constructor method = [](Args... args) -> BaseT* { return new DerivedT(std::move(args)...); };
     ModuleRegistry::addModule<BaseT, DerivedT, Args...>(type, method);
   }
 
@@ -377,7 +377,7 @@ struct ObjectFactory {
       return nullptr;
     }
 
-    return std::unique_ptr<BaseT>(factory(args...));
+    return std::unique_ptr<BaseT>(factory(std::move(args)...));
   }
 };
 
@@ -394,7 +394,7 @@ struct ObjectWithConfigFactory {
     const Constructor method = [](const YAML::Node& data, Args... args) -> BaseT* {
       DerivedConfigT config;
       Visitor::setValues(config, data);
-      return new DerivedT(config, args...);
+      return new DerivedT(config, std::move(args)...);
     };
 
     ModuleRegistry::addModule<BaseT, DerivedT, const YAML::Node&, Args...>(type, method, true);
@@ -411,7 +411,7 @@ struct ObjectWithConfigFactory {
       return nullptr;
     }
 
-    return std::unique_ptr<BaseT>(factory(data, args...));
+    return std::unique_ptr<BaseT>(factory(data, std::move(args)...));
   }
 };
 
@@ -469,7 +469,7 @@ struct RegistrationWithConfig {
  */
 template <typename BaseT, typename... ConstructorArguments>
 std::unique_ptr<BaseT> create(const std::string& type, ConstructorArguments... args) {
-  return internal::ObjectFactory<BaseT, ConstructorArguments...>::create(type, args...);
+  return internal::ObjectFactory<BaseT, ConstructorArguments...>::create(type, std::move(args)...);
 }
 
 }  // namespace config

--- a/config_utilities/include/config_utilities/factory.h
+++ b/config_utilities/include/config_utilities/factory.h
@@ -242,8 +242,8 @@ class ModuleRegistry {
     }
 
     // wrap factory call to register any allocations
-    return [factory, key, type, create_callback](Args&&... args) -> BaseT* {
-      auto pointer = factory(std::forward<Args>(args)...);
+    return [factory, key, type, create_callback](Args... args) -> BaseT* {
+      auto pointer = factory(args...);
       create_callback(key, type, pointer);
       return pointer;
     };
@@ -367,17 +367,17 @@ struct ObjectFactory {
   // Add entries.
   template <typename DerivedT>
   static void addEntry(const std::string& type) {
-    const Constructor method = [](Args&&... args) -> BaseT* { return new DerivedT(std::forward<Args>(args)...); };
+    const Constructor method = [](Args... args) -> BaseT* { return new DerivedT(args...); };
     ModuleRegistry::addModule<BaseT, DerivedT, Args...>(type, method);
   }
 
-  static std::unique_ptr<BaseT> create(const std::string& type, Args&&... args) {
+  static std::unique_ptr<BaseT> create(const std::string& type, Args... args) {
     const auto factory = ModuleRegistry::getModule<BaseT, Args...>(type, registration_info);
     if (!factory) {
       return nullptr;
     }
 
-    return std::unique_ptr<BaseT>(factory(std::forward<Args>(args)...));
+    return std::unique_ptr<BaseT>(factory(args...));
   }
 };
 
@@ -391,16 +391,16 @@ struct ObjectWithConfigFactory {
   // Add entries.
   template <typename DerivedT, typename DerivedConfigT>
   static void addEntry(const std::string& type) {
-    const Constructor method = [](const YAML::Node& data, Args&&... args) -> BaseT* {
+    const Constructor method = [](const YAML::Node& data, Args... args) -> BaseT* {
       DerivedConfigT config;
       Visitor::setValues(config, data);
-      return new DerivedT(config, std::forward<Args>(args)...);
+      return new DerivedT(config, args...);
     };
 
     ModuleRegistry::addModule<BaseT, DerivedT, const YAML::Node&, Args...>(type, method, true);
   }
 
-  static std::unique_ptr<BaseT> create(const YAML::Node& data, Args&&... args) {
+  static std::unique_ptr<BaseT> create(const YAML::Node& data, Args... args) {
     std::string type;
     if (!getType(data, type)) {
       return nullptr;
@@ -411,7 +411,7 @@ struct ObjectWithConfigFactory {
       return nullptr;
     }
 
-    return std::unique_ptr<BaseT>(factory(data, std::forward<Args>(args)...));
+    return std::unique_ptr<BaseT>(factory(data, args...));
   }
 };
 
@@ -468,9 +468,8 @@ struct RegistrationWithConfig {
  * @returns Unique pointer of type base that contains the derived object.
  */
 template <typename BaseT, typename... ConstructorArguments>
-std::unique_ptr<BaseT> create(const std::string& type, ConstructorArguments&&... args) {
-  return internal::ObjectFactory<BaseT, ConstructorArguments...>::create(type,
-    std::forward<ConstructorArguments>(args)...);
+std::unique_ptr<BaseT> create(const std::string& type, ConstructorArguments... args) {
+  return internal::ObjectFactory<BaseT, ConstructorArguments...>::create(type, args...);
 }
 
 }  // namespace config

--- a/config_utilities/include/config_utilities/internal/config_context.h
+++ b/config_utilities/include/config_utilities/internal/config_context.h
@@ -59,13 +59,14 @@ class Context {
 
   template <typename BaseT, typename... ConstructorArguments>
   static std::unique_ptr<BaseT> create(ConstructorArguments... args) {
-    return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(instance().contents_, args...);
+    return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(instance().contents_,
+      std::move(args)...);
   }
 
   template <typename BaseT, typename... ConstructorArguments>
   static std::unique_ptr<BaseT> createNamespaced(const std::string& name_space, ConstructorArguments... args) {
     const auto ns_node = internal::lookupNamespace(instance().contents_, name_space);
-    return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(ns_node, args...);
+    return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(ns_node, std::move(args)...);
   }
 
   template <typename ConfigT>

--- a/config_utilities/include/config_utilities/internal/config_context.h
+++ b/config_utilities/include/config_utilities/internal/config_context.h
@@ -58,16 +58,14 @@ class Context {
   static YAML::Node toYaml();
 
   template <typename BaseT, typename... ConstructorArguments>
-  static std::unique_ptr<BaseT> create(ConstructorArguments&&... args) {
-    return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(instance().contents_,
-    std::forward<ConstructorArguments>(args)...);
+  static std::unique_ptr<BaseT> create(ConstructorArguments... args) {
+    return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(instance().contents_, args...);
   }
 
   template <typename BaseT, typename... ConstructorArguments>
-  static std::unique_ptr<BaseT> createNamespaced(const std::string& name_space, ConstructorArguments&&... args) {
+  static std::unique_ptr<BaseT> createNamespaced(const std::string& name_space, ConstructorArguments... args) {
     const auto ns_node = internal::lookupNamespace(instance().contents_, name_space);
-    return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(ns_node,
-      std::forward<ConstructorArguments>(args)...);
+    return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(ns_node, args...);
   }
 
   template <typename ConfigT>

--- a/config_utilities/include/config_utilities/parsing/commandline.h
+++ b/config_utilities/include/config_utilities/parsing/commandline.h
@@ -116,7 +116,7 @@ template <typename BaseT, typename... ConstructorArguments>
 std::unique_ptr<BaseT> createFromCLI(int argc, char* argv[], ConstructorArguments... args) {
   // when parsing CLI locally we don't want to modify the arguments ever
   const auto node = internal::loadFromArguments(argc, argv, false);
-  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(node, args...);
+  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(node, std::move(args)...);
 }
 
 /**
@@ -133,7 +133,7 @@ std::unique_ptr<BaseT> createFromCLI(int argc, char* argv[], ConstructorArgument
 template <typename BaseT, typename... ConstructorArguments>
 std::unique_ptr<BaseT> createFromCLI(const std::vector<std::string>& argv, ConstructorArguments... args) {
   const auto node = internal::loadFromArguments(argv);
-  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(node, args...);
+  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(node, std::move(args)...);
 }
 
 /**
@@ -157,7 +157,7 @@ std::unique_ptr<BaseT> createFromCLIWithNamespace(int argc,
   // when parsing CLI locally we don't want to modify the arguments ever
   const auto node = internal::loadFromArguments(argc, argv, false);
   const auto ns_node = internal::lookupNamespace(node, name_space);
-  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(ns_node, args...);
+  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(ns_node, std::move(args)...);
 }
 
 /**
@@ -178,7 +178,7 @@ std::unique_ptr<BaseT> createFromCLIWithNamespace(const std::vector<std::string>
                                                   ConstructorArguments... args) {
   const auto node = internal::loadFromArguments(argv);
   const auto ns_node = internal::lookupNamespace(node, name_space);
-  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(ns_node, args...);
+  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(ns_node, std::move(args)...);
 }
 
 }  // namespace config

--- a/config_utilities/include/config_utilities/parsing/commandline.h
+++ b/config_utilities/include/config_utilities/parsing/commandline.h
@@ -113,11 +113,10 @@ ConfigT fromCLI(const std::vector<std::string>& args, const std::string& name_sp
  * @returns Unique pointer of type base that contains the derived object.
  */
 template <typename BaseT, typename... ConstructorArguments>
-std::unique_ptr<BaseT> createFromCLI(int argc, char* argv[], ConstructorArguments&&... args) {
+std::unique_ptr<BaseT> createFromCLI(int argc, char* argv[], ConstructorArguments... args) {
   // when parsing CLI locally we don't want to modify the arguments ever
   const auto node = internal::loadFromArguments(argc, argv, false);
-  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(node,
-    std::forward<ConstructorArguments>(args)...);
+  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(node, args...);
 }
 
 /**
@@ -132,10 +131,9 @@ std::unique_ptr<BaseT> createFromCLI(int argc, char* argv[], ConstructorArgument
  * @returns Unique pointer of type base that contains the derived object.
  */
 template <typename BaseT, typename... ConstructorArguments>
-std::unique_ptr<BaseT> createFromCLI(const std::vector<std::string>& argv, ConstructorArguments&&... args) {
+std::unique_ptr<BaseT> createFromCLI(const std::vector<std::string>& argv, ConstructorArguments... args) {
   const auto node = internal::loadFromArguments(argv);
-  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(node,
-    std::forward<ConstructorArguments>(args)...);
+  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(node, args...);
 }
 
 /**
@@ -155,12 +153,11 @@ template <typename BaseT, typename... ConstructorArguments>
 std::unique_ptr<BaseT> createFromCLIWithNamespace(int argc,
                                                   char* argv[],
                                                   const std::string& name_space,
-                                                  ConstructorArguments&&... args) {
+                                                  ConstructorArguments... args) {
   // when parsing CLI locally we don't want to modify the arguments ever
   const auto node = internal::loadFromArguments(argc, argv, false);
   const auto ns_node = internal::lookupNamespace(node, name_space);
-  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(ns_node,
-    std::forward<ConstructorArguments>(args)...);
+  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(ns_node, args...);
 }
 
 /**
@@ -178,11 +175,10 @@ std::unique_ptr<BaseT> createFromCLIWithNamespace(int argc,
 template <typename BaseT, typename... ConstructorArguments>
 std::unique_ptr<BaseT> createFromCLIWithNamespace(const std::vector<std::string>& argv,
                                                   const std::string& name_space,
-                                                  ConstructorArguments&&... args) {
+                                                  ConstructorArguments... args) {
   const auto node = internal::loadFromArguments(argv);
   const auto ns_node = internal::lookupNamespace(node, name_space);
-  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(ns_node,
-    std::forward<ConstructorArguments>(args)...);
+  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(ns_node, args...);
 }
 
 }  // namespace config

--- a/config_utilities/include/config_utilities/parsing/context.h
+++ b/config_utilities/include/config_utilities/parsing/context.h
@@ -90,7 +90,7 @@ ConfigT fromContext(const std::string& name_space = "") {
  */
 template <typename BaseT, typename... ConstructorArguments>
 std::unique_ptr<BaseT> createFromContext(ConstructorArguments... args) {
-  return internal::Context::create<BaseT, ConstructorArguments...>(args...);
+  return internal::Context::create<BaseT, ConstructorArguments...>(std::move(args)...);
 }
 
 /**

--- a/config_utilities/include/config_utilities/parsing/yaml.h
+++ b/config_utilities/include/config_utilities/parsing/yaml.h
@@ -129,9 +129,8 @@ bool toYamlFile(const ConfigT& config, const std::string& file_name) {
  * @returns Unique pointer of type base that contains the derived object.
  */
 template <typename BaseT, typename... ConstructorArguments>
-std::unique_ptr<BaseT> createFromYaml(const YAML::Node& node, ConstructorArguments&&... args) {
-  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(node,
-    std::forward<ConstructorArguments>(args)...);
+std::unique_ptr<BaseT> createFromYaml(const YAML::Node& node, ConstructorArguments... args) {
+  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(node, args...);
 }
 
 /**
@@ -152,10 +151,9 @@ std::unique_ptr<BaseT> createFromYaml(const YAML::Node& node, ConstructorArgumen
 template <typename BaseT, typename... ConstructorArguments>
 std::unique_ptr<BaseT> createFromYamlWithNamespace(const YAML::Node& node,
                                                    const std::string& name_space,
-                                                   ConstructorArguments&&... args) {
+                                                   ConstructorArguments... args) {
   const YAML::Node ns_node = internal::lookupNamespace(node, name_space);
-  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(ns_node,
-    std::forward<ConstructorArguments>(args)...);
+  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(ns_node, args...);
 }
 
 /**
@@ -172,9 +170,8 @@ std::unique_ptr<BaseT> createFromYamlWithNamespace(const YAML::Node& node,
  * @returns Unique pointer of type base that contains the derived object.
  */
 template <typename BaseT, typename... ConstructorArguments>
-std::unique_ptr<BaseT> createFromYamlFile(const std::string& file_name, ConstructorArguments&&... args) {
-  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(YAML::LoadFile(file_name),
-    std::forward<ConstructorArguments>(args)...);
+std::unique_ptr<BaseT> createFromYamlFile(const std::string& file_name, ConstructorArguments... args) {
+  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(YAML::LoadFile(file_name), args...);
 }
 
 /**
@@ -195,10 +192,9 @@ std::unique_ptr<BaseT> createFromYamlFile(const std::string& file_name, Construc
 template <typename BaseT, typename... ConstructorArguments>
 std::unique_ptr<BaseT> createFromYamlFileWithNamespace(const std::string& file_name,
                                                        const std::string& name_space,
-                                                       ConstructorArguments&&... args) {
+                                                       ConstructorArguments... args) {
   const YAML::Node node = internal::lookupNamespace(YAML::LoadFile(file_name), name_space);
-  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(node,
-    std::forward<ConstructorArguments>(args)...);
+  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(node, args...);
 }
 
 /**

--- a/config_utilities/include/config_utilities/parsing/yaml.h
+++ b/config_utilities/include/config_utilities/parsing/yaml.h
@@ -130,7 +130,7 @@ bool toYamlFile(const ConfigT& config, const std::string& file_name) {
  */
 template <typename BaseT, typename... ConstructorArguments>
 std::unique_ptr<BaseT> createFromYaml(const YAML::Node& node, ConstructorArguments... args) {
-  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(node, args...);
+  return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(node, std::move(args)...);
 }
 
 /**

--- a/config_utilities/include/config_utilities/virtual_config.h
+++ b/config_utilities/include/config_utilities/virtual_config.h
@@ -181,7 +181,7 @@ class VirtualConfig {
     // also be de-serialized so this should not result in any warnings, we print them anyways to be sure. The factory
     // should take proper care of any other verbose error management.
     const internal::MetaData data = internal::Visitor::getValues(*this);
-    return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(data.data, args...);
+    return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(data.data, std::move(args)...);
   }
 
  private:

--- a/config_utilities/include/config_utilities/virtual_config.h
+++ b/config_utilities/include/config_utilities/virtual_config.h
@@ -172,7 +172,7 @@ class VirtualConfig {
    * @return The created object of DerivedT that inherits from BaseT.
    */
   template <typename... ConstructorArguments>
-  std::unique_ptr<BaseT> create(ConstructorArguments&&... args) const {
+  std::unique_ptr<BaseT> create(ConstructorArguments... args) const {
     if (!config_) {
       return nullptr;
     }
@@ -181,8 +181,7 @@ class VirtualConfig {
     // also be de-serialized so this should not result in any warnings, we print them anyways to be sure. The factory
     // should take proper care of any other verbose error management.
     const internal::MetaData data = internal::Visitor::getValues(*this);
-    return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(data.data,
-      std::forward<ConstructorArguments>(args)...);
+    return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(data.data, args...);
   }
 
  private:

--- a/config_utilities/test/tests/factory.cpp
+++ b/config_utilities/test/tests/factory.cpp
@@ -103,6 +103,53 @@ void declare_config(DerivedD::Config& config) {
   config::field(config.i, "i");
 }
 
+class DerivedWithMoveOnlyParameter : public Base {
+ public:
+  explicit DerivedWithMoveOnlyParameter(std::unique_ptr<int> i) : Base(*i), i_(std::move(i)) {}
+  std::string name() const override { return "DerivedWithMoveOnlyParameter"; }
+
+  const std::unique_ptr<int> i_;
+ private:
+  inline static const auto registration_ =
+    config::Registration<Base, DerivedWithMoveOnlyParameter, std::unique_ptr<int>>("DerivedWithMoveOnlyParameter");
+};
+
+class DerivedWithComplexParameter : public Base {
+ public:
+  explicit DerivedWithComplexParameter(std::shared_ptr<int> i) : Base(*i), i_(std::move(i)) {}
+  std::string name() const override { return "DerivedWithComplexParameter"; }
+
+  std::shared_ptr<int> i_;
+ private:
+  inline static const auto registration_ =
+    config::Registration<Base, DerivedWithComplexParameter, std::shared_ptr<int>>("DerivedWithComplexParameter");
+};
+
+class DerivedWithMoveOnlyParameterAndConfig : public Base {
+ public:
+  struct Config {
+    float f = 123.f;
+  };
+
+  DerivedWithMoveOnlyParameterAndConfig(const Config& config, std::unique_ptr<int> i) :
+    Base(*i), i_(std::move(i)), config_(config) {}
+  std::string name() const override { return "DerivedWithMoveOnlyParameterAndConfig"; }
+
+  const std::unique_ptr<int> i_;
+  Config config_;
+
+ private:
+  inline static const auto registration_ =
+    config::RegistrationWithConfig<Base, DerivedWithMoveOnlyParameterAndConfig, Config, std::unique_ptr<int>>(
+      "DerivedWithMoveOnlyParameterAndConfig");
+};
+
+void declare_config(DerivedWithMoveOnlyParameterAndConfig::Config & config) {
+  // Declare the config using the config utilities.
+  config::name("DerivedWithMoveOnlyParameterAndConfig");
+  config::field(config.f, "f");
+}
+
 template <typename T>
 struct TemplatedBase {
   virtual ~TemplatedBase() = default;
@@ -133,31 +180,104 @@ TEST(Factory, moduleInfo) {
 }
 
 TEST(Factory, create) {
-  std::unique_ptr<Base> base = create<Base>("DerivedA", 1);
-  EXPECT_TRUE(base);
-  EXPECT_EQ(base->name(), "DerivedA");
-
-  base = create<Base>("DerivedB", 1);
-  EXPECT_TRUE(base);
-  EXPECT_EQ(base->name(), "DerivedB");
-
-  auto logger = TestLogger::create();
-  base = create<Base>("NotRegistered", 1);
-  EXPECT_FALSE(base);
-  ASSERT_EQ(logger->numMessages(), 1);
-  std::string msg = logger->messages().back().second;
-  EXPECT_EQ(msg.find("No module of type 'NotRegistered' registered to the factory"), 0);
-  EXPECT_NE(msg.find("Registered are: 'DerivedA', 'DerivedB'."), std::string::npos) << msg;
-
-  base = create<Base>("DerivedA", 1, 2.f);
-  EXPECT_FALSE(base);
-  ASSERT_GE(logger->numMessages(), 2);
-  msg = logger->messages().at(1).second;
-  EXPECT_EQ(msg.find("Cannot create a module of type 'DerivedA': No modules registered to the factory"), 0);
-  EXPECT_NE(
-      msg.find(
-          "Register modules using a static config::Registration<BaseT, DerivedT, ConstructorArguments...> struct."),
-      std::string::npos);
+  {
+    auto base = create<Base>("DerivedA", 1);
+    EXPECT_TRUE(base);
+    EXPECT_EQ(base->name(), "DerivedA");
+  }
+  {
+    // Create b with an r-value
+    auto base = create<Base>("DerivedB", 1);
+    EXPECT_TRUE(base);
+    EXPECT_EQ(base->name(), "DerivedB");
+  }
+  {
+    // Create b with an l-value
+    int i = 1;
+    auto base = create<Base>("DerivedB", i);
+    EXPECT_TRUE(base);
+    EXPECT_EQ(base->name(), "DerivedB");
+  }
+  {
+    // Create b with an r-value reference
+    int i = 1;
+    auto base = create<Base>("DerivedB", std::move(i));
+    EXPECT_TRUE(base);
+    EXPECT_EQ(base->name(), "DerivedB");
+  }
+  {
+    // Try to create an object that is not registered
+    auto logger = TestLogger::create();
+    auto base = create<Base>("NotRegistered", 1);
+    EXPECT_FALSE(base);
+    ASSERT_EQ(logger->numMessages(), 1);
+    std::string msg = logger->messages().back().second;
+    EXPECT_EQ(msg.find("No module of type 'NotRegistered' registered to the factory"), 0);
+    EXPECT_NE(msg.find("Registered are: 'DerivedA', 'DerivedB'."), std::string::npos) << msg;
+  }
+  {
+    // Try to create an object that is registered but with the wrong arguments
+    auto logger = TestLogger::create();
+    auto base = create<Base>("DerivedA", 1, 2.f);
+    EXPECT_FALSE(base);
+    ASSERT_EQ(logger->numMessages(), 1);
+    auto msg = logger->messages().back().second;
+    EXPECT_EQ(msg.find("Cannot create a module of type 'DerivedA': No modules registered to the factory"), 0);
+    EXPECT_NE(
+        msg.find(
+            "Register modules using a static config::Registration<BaseT, DerivedT, ConstructorArguments...> struct."),
+        std::string::npos);
+  }
+  {
+    // Try to create an object that takes a move-only parameter r-value
+    auto base = create<Base>("DerivedWithMoveOnlyParameter", std::make_unique<int>(1));
+    EXPECT_TRUE(base);
+    EXPECT_EQ(base->i_, 1);
+    EXPECT_EQ(base->name(), "DerivedWithMoveOnlyParameter");
+    auto ptr = dynamic_cast<DerivedWithMoveOnlyParameter*>(base.get());
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(*ptr->i_, 1);
+  }
+  {
+    // Try to create an object that takes a move-only parameter l-value
+    auto i = std::make_unique<int>(1);
+    auto base = create<Base>("DerivedWithMoveOnlyParameter", std::move(i));
+    EXPECT_TRUE(base);
+    EXPECT_EQ(base->i_, 1);
+    EXPECT_EQ(base->name(), "DerivedWithMoveOnlyParameter");
+    auto ptr = dynamic_cast<DerivedWithMoveOnlyParameter*>(base.get());
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(*ptr->i_, 1);
+  }
+  {
+    // Try to create an object that takes a complex parameter by copy from an l-value
+    auto i = std::make_shared<int>(1);
+    auto base = create<Base>("DerivedWithComplexParameter", i);
+    EXPECT_TRUE(base);
+    EXPECT_EQ(base->i_, 1);
+    EXPECT_EQ(base->name(), "DerivedWithComplexParameter");
+    auto ptr = dynamic_cast<DerivedWithComplexParameter*>(base.get());
+    ASSERT_NE(ptr, nullptr);
+  }
+  {
+    // Try to create an object that takes a complex parameter by copy from an r-value
+    auto base = create<Base>("DerivedWithComplexParameter", std::make_shared<int>(1));
+    EXPECT_TRUE(base);
+    EXPECT_EQ(base->i_, 1);
+    EXPECT_EQ(base->name(), "DerivedWithComplexParameter");
+    auto ptr = dynamic_cast<DerivedWithComplexParameter*>(base.get());
+    ASSERT_NE(ptr, nullptr);
+  }
+  {
+    // Try to create an object that takes a complex parameter using an r-value reference
+    auto i = std::make_shared<int>(1);
+    auto base = create<Base>("DerivedWithComplexParameter", std::move(i));
+    EXPECT_TRUE(base);
+    EXPECT_EQ(base->i_, 1);
+    EXPECT_EQ(base->name(), "DerivedWithComplexParameter");
+    auto ptr = dynamic_cast<DerivedWithComplexParameter*>(base.get());
+    ASSERT_NE(ptr, nullptr);
+  }
 }
 
 TEST(Factory, createWithConfig) {
@@ -165,33 +285,90 @@ TEST(Factory, createWithConfig) {
   data["i"] = 3;
   data["f"] = 3.14f;
   data["type"] = "DerivedC";
-
-  std::unique_ptr<Base> base = createFromYaml<Base>(data, 12);
-  EXPECT_TRUE(base);
-  EXPECT_EQ(base->name(), "DerivedC");
-  EXPECT_EQ(dynamic_cast<DerivedC*>(base.get())->config_.f, 3.14f);
-  EXPECT_EQ(base->i_, 12);
-
-  auto logger = TestLogger::create();
-  data["type"] = "NotRegistered";
-  base = createFromYaml<Base>(data, 12);
-  EXPECT_FALSE(base);
-  EXPECT_EQ(logger->numMessages(), 1);
-  std::string msg = logger->messages().back().second;
-  EXPECT_EQ(msg.find("No module of type 'NotRegistered' registered to the factory"), 0);
-
-  Settings().factory_type_param_name = "test_type";
-  base = createFromYaml<Base>(data, 12);
-  EXPECT_FALSE(base);
-  EXPECT_EQ(logger->numMessages(), 2);
-  msg = logger->messages().back().second;
-  EXPECT_EQ(msg, "Could not read the param 'test_type' to deduce the type of the module to create.");
-
-  data["test_type"] = "DerivedD";
-  base = createFromYaml<Base>(data, 12);
-  EXPECT_TRUE(base);
-  EXPECT_EQ(base->name(), "DerivedD");
-  EXPECT_EQ(dynamic_cast<DerivedD*>(base.get())->config_.i, 3);
+  {
+    // Create DerivedC with config and r-value parameter
+    auto base = createFromYaml<Base>(data, 12);
+    EXPECT_TRUE(base);
+    EXPECT_EQ(base->name(), "DerivedC");
+    EXPECT_EQ(dynamic_cast<DerivedC*>(base.get())->config_.f, 3.14f);
+    EXPECT_EQ(base->i_, 12);
+  }
+  {
+    // Create DerivedC with config and l-value parameter
+    int i = 12;
+    auto base = createFromYaml<Base>(data, i);
+    EXPECT_TRUE(base);
+    EXPECT_EQ(base->name(), "DerivedC");
+    EXPECT_EQ(dynamic_cast<DerivedC*>(base.get())->config_.f, 3.14f);
+    EXPECT_EQ(base->i_, 12);
+  }
+  {
+    // Create DerivedC with config and const l-value parameter
+    const int i = 12;
+    auto base = createFromYaml<Base>(data, i);
+    EXPECT_TRUE(base);
+    EXPECT_EQ(base->name(), "DerivedC");
+    EXPECT_EQ(dynamic_cast<DerivedC*>(base.get())->config_.f, 3.14f);
+    EXPECT_EQ(base->i_, 12);
+  }
+  {
+    // Create DerivedC with config and an r-value reference
+    int i = 12;
+    auto base = createFromYaml<Base>(data, std::move(i));
+    EXPECT_TRUE(base);
+    EXPECT_EQ(base->name(), "DerivedC");
+    EXPECT_EQ(dynamic_cast<DerivedC*>(base.get())->config_.f, 3.14f);
+    EXPECT_EQ(base->i_, 12);
+  }
+  {
+    auto logger = TestLogger::create();
+    data["type"] = "NotRegistered";
+    auto base = createFromYaml<Base>(data, 12);
+    EXPECT_FALSE(base);
+    EXPECT_EQ(logger->numMessages(), 1);
+    std::string msg = logger->messages().back().second;
+    EXPECT_EQ(msg.find("No module of type 'NotRegistered' registered to the factory"), 0);
+  }
+  {
+    auto logger = TestLogger::create();
+    Settings().factory_type_param_name = "test_type";
+    auto base = createFromYaml<Base>(data, 12);
+    EXPECT_FALSE(base);
+    EXPECT_EQ(logger->numMessages(), 1);
+    auto msg = logger->messages().back().second;
+    EXPECT_EQ(msg, "Could not read the param 'test_type' to deduce the type of the module to create.");
+  }
+  {
+    data["test_type"] = "DerivedD";
+    auto base = createFromYaml<Base>(data, 12);
+    EXPECT_TRUE(base);
+    EXPECT_EQ(base->name(), "DerivedD");
+    EXPECT_EQ(dynamic_cast<DerivedD*>(base.get())->config_.i, 3);
+  }
+  {
+    // Build with r-value move-only parameter
+    Settings().restoreDefaults();
+    data["type"] = "DerivedWithMoveOnlyParameterAndConfig";
+    auto base = createFromYaml<Base>(data, std::make_unique<int>(1));
+    EXPECT_TRUE(base);
+    EXPECT_EQ(base->name(), "DerivedWithMoveOnlyParameterAndConfig");
+    auto ptr = dynamic_cast<DerivedWithMoveOnlyParameterAndConfig*>(base.get());
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_FLOAT_EQ(ptr->config_.f, 3.14f);
+    EXPECT_EQ(*ptr->i_, 1);
+  }
+  {
+    // Build with l-value move-only parameter
+    data["type"] = "DerivedWithMoveOnlyParameterAndConfig";
+    auto i = std::make_unique<int>(1);
+    auto base = createFromYaml<Base>(data, std::move(i));
+    EXPECT_TRUE(base);
+    EXPECT_EQ(base->name(), "DerivedWithMoveOnlyParameterAndConfig");
+    auto ptr = dynamic_cast<DerivedWithMoveOnlyParameterAndConfig*>(base.get());
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_FLOAT_EQ(ptr->config_.f, 3.14f);
+    EXPECT_EQ(*ptr->i_, 1);
+  }
 }
 
 TEST(Factory, moduleNameConflicts) {
@@ -250,6 +427,12 @@ config::test::Base(int):
   'DerivedA' (config::test::DerivedA)
   'DerivedB' (config::test::DerivedB)
 
+config::test::Base(std::shared_ptr<int>):
+  'DerivedWithComplexParameter' (config::test::DerivedWithComplexParameter)
+
+config::test::Base(std::unique_ptr<int, std::default_delete<int> >):
+  'DerivedWithMoveOnlyParameter' (config::test::DerivedWithMoveOnlyParameter)
+
 config::test::Talker():
   'internal' (config::test::InternalTalker)
 
@@ -276,9 +459,18 @@ config::test::Base(int):
   'DerivedC' (config::test::DerivedC)
   'DerivedD' (config::test::DerivedD)
 
+config::test::Base(std::unique_ptr<int, std::default_delete<int> >):
+  'DerivedWithMoveOnlyParameterAndConfig' (config::test::DerivedWithMoveOnlyParameterAndConfig)
+
 config::test::Base2():
   'Derived2' (config::test::Derived2)
   'Derived2A' (config::test::Derived2A)
+
+config::test::Base2(std::shared_ptr<int>):
+  'Derived2WithComplexParam' (config::test::Derived2WithComplexParam)
+
+config::test::Base2(std::unique_ptr<int, std::default_delete<int> >):
+  'Derived2WithMoveOnlyParam' (config::test::Derived2WithMoveOnlyParam)
 
 config::test::ProcessorBase():
   'AddString' (config::test::AddString)
@@ -293,10 +485,13 @@ config::test::Talker():
 Config[config::test::Base]():
   'DerivedC' (config::test::DerivedC::Config)
   'DerivedD' (config::test::DerivedD::Config)
+  'DerivedWithMoveOnlyParameterAndConfig' (config::test::DerivedWithMoveOnlyParameterAndConfig::Config)
 
 Config[config::test::Base2]():
   'Derived2' (config::test::Derived2::Config)
   'Derived2A' (config::test::Derived2A::Config)
+  'Derived2WithComplexParam' (config::test::Derived2WithComplexParam::Config)
+  'Derived2WithMoveOnlyParam' (config::test::Derived2WithMoveOnlyParam::Config)
 
 Config[config::test::ProcessorBase]():
   'AddString' (config::test::AddString::Config)

--- a/config_utilities/test/tests/factory.cpp
+++ b/config_utilities/test/tests/factory.cpp
@@ -194,64 +194,6 @@ TEST(Factory, createWithConfig) {
   EXPECT_EQ(dynamic_cast<DerivedD*>(base.get())->config_.i, 3);
 }
 
-struct MoveOnlyBase {
-  virtual ~MoveOnlyBase() = default;
-  virtual void print() { std::cout << "Hi! I'm Base\n"; }
-};
-
-struct MoveOnlyDerived : public MoveOnlyBase {
-  explicit MoveOnlyDerived(std::unique_ptr<int> i) : i_(std::move(i)) {}
-  ~MoveOnlyDerived() override = default;
-
-  std::unique_ptr<int> i_;
-  inline static const auto registration =
-    config::Registration<MoveOnlyBase, MoveOnlyDerived, std::unique_ptr<int>>("MoveOnlyDerived");
-};
-
-struct MoveOnlyDerivedWithConfig : public MoveOnlyBase {
-  struct Config {
-    int i = 0;
-  };
-
-  explicit MoveOnlyDerivedWithConfig(const Config& config, std::unique_ptr<int> i) : config_(config), i_(std::move(i)) {}
-  ~MoveOnlyDerivedWithConfig() override = default;
-
-  Config config_;
-  std::unique_ptr<int> i_;
-  inline static const auto registration =
-    config::RegistrationWithConfig<MoveOnlyBase, MoveOnlyDerivedWithConfig, Config, std::unique_ptr<int>>(
-      "MoveOnlyDerivedWithConfig");
-};
-
-void declare_config(MoveOnlyDerivedWithConfig::Config& config) {
-  // Declare the config using the config utilities.
-  config::name("MoveOnlyDerivedWithConfig");
-  config::field(config.i, "i");
-}
-
-TEST(Factory, createWithMoveOnlyArgument) {
-  {
-    auto i = std::make_unique<int>(42);
-    auto base = config::create<MoveOnlyBase>("MoveOnlyDerived", std::move(i));
-    EXPECT_NE(base, nullptr);
-    auto ptr = dynamic_cast<MoveOnlyDerived*>(base.get());
-    EXPECT_NE(ptr, nullptr);
-    EXPECT_EQ(*ptr->i_, 42);
-  }
-  {
-    auto i = std::make_unique<int>(24);
-    YAML::Node yaml;
-    yaml["type"] = "MoveOnlyDerivedWithConfig";
-    yaml["i"] = 24;
-
-    auto base = config::createFromYaml<MoveOnlyBase>(yaml, std::move(i));
-    EXPECT_NE(base, nullptr);
-    auto ptr = dynamic_cast<MoveOnlyDerivedWithConfig*>(base.get());
-    EXPECT_NE(ptr, nullptr);
-    EXPECT_EQ(*ptr->i_, 24);
-  }
-}
-
 TEST(Factory, moduleNameConflicts) {
   auto logger = TestLogger::create();
 
@@ -308,9 +250,6 @@ config::test::Base(int):
   'DerivedA' (config::test::DerivedA)
   'DerivedB' (config::test::DerivedB)
 
-config::test::MoveOnlyBase(std::unique_ptr<int, std::default_delete<int> >):
-  'MoveOnlyDerived' (config::test::MoveOnlyDerived)
-
 config::test::Talker():
   'internal' (config::test::InternalTalker)
 
@@ -341,9 +280,6 @@ config::test::Base2():
   'Derived2' (config::test::Derived2)
   'Derived2A' (config::test::Derived2A)
 
-config::test::MoveOnlyBase(std::unique_ptr<int, std::default_delete<int> >):
-  'MoveOnlyDerivedWithConfig' (config::test::MoveOnlyDerivedWithConfig)
-
 config::test::ProcessorBase():
   'AddString' (config::test::AddString)
 
@@ -361,9 +297,6 @@ Config[config::test::Base]():
 Config[config::test::Base2]():
   'Derived2' (config::test::Derived2::Config)
   'Derived2A' (config::test::Derived2A::Config)
-
-Config[config::test::MoveOnlyBase]():
-  'MoveOnlyDerivedWithConfig' (config::test::MoveOnlyDerivedWithConfig::Config)
 
 Config[config::test::ProcessorBase]():
   'AddString' (config::test::AddString::Config)


### PR DESCRIPTION
@nathanhhughes 

Unfortunately, my previous PR #44, while adding support for move only types, actually ended up introducing a bug where l-values end up being casted to r-value references. This casting then makes the factory function lookup fail. The following unit test looks like it should work, but doesn't actually pass after #44. The reason the PR unit tests pass is because all the factory unit tests were written with r-values and no l-values.

```c++
class Base {
 public:
  explicit Base(int i) : i_(i) {}
  virtual ~Base() = default;
  const int i_;
  virtual std::string name() const = 0;
};

class DerivedB : public Base {
 public:
  explicit DerivedB(int i) : Base(i) {}
  std::string name() const override { return "DerivedB"; }
  inline static const auto registration_ = config::Registration<Base, DerivedB, int>("DerivedB");
};

TEST(Factory, lvalueCreate) {
  int i = 1;
  auto base = create<Base>("DerivedB", i);
  EXPECT_TRUE(base);
  EXPECT_EQ(base->name(), "DerivedB");
}
```

With the error being:

```
unknown file: Failure
C++ exception with description "Invalid module map for type 'DerivedB' 
and info BaseT='config::test::Base' and ConstructorArguments={'int'}" thrown in the test body.
```

My understanding here is that the function signature with the forwarding reference `&&` below causes the incorrect type to be deduced.
```c++
template <typename BaseT, typename... ConstructorArguments>
std::unique_ptr<BaseT> create(const std::string& type, ConstructorArguments&&... args)
```
The type of `args` ends up being deduced as `int&` through [reference collapsing rules](https://en.cppreference.com/w/cpp/language/reference#Reference_collapsing), which then ends up causing a factory method lookup failure later. As proof of this theory, we can actually make the test pass by casting to i to int. Or explicitly specifying `ConstructorArguments` and `std::move`'ing `i` to allow the r-value reference to bind to `i`.

```c++
TEST(Factory, lvalueCreate) {
  int i = 1;
  auto base = create<Base>("DerivedB", static_cast<int>(i));
  // This also works: create<Base, int>("DerivedB", std::move(i));
  EXPECT_TRUE(base);
  EXPECT_EQ(base->name(), "DerivedB");
}
```

# The fix
This PR fixes the issue by first reverting the previous commit, and then adding `std::move` instead of `std::forward` everywhere the args are used. Several unit tests are added to ensure r-value, r-value reference, l-value, const l-value and move only types work correctly.