### PR TITLE
add ability to specify absolute path conversion when parsing

### DIFF
--- a/config_utilities/include/config_utilities/types/path.h
+++ b/config_utilities/include/config_utilities/types/path.h
@@ -73,6 +73,14 @@ struct Path {
   static std::string toIntermediate(std::string value, std::string&);
   static void fromIntermediate(const std::string& intermediate, std::string& value, std::string&);
 
+  struct Absolute {
+    // Path conversion converts a path or string into its lexically normal form.
+    static std::string toIntermediate(const std::filesystem::path& value, std::string&);
+    static void fromIntermediate(const std::string& intermediate, std::filesystem::path& value, std::string&);
+    static std::string toIntermediate(std::string value, std::string&);
+    static void fromIntermediate(const std::string& intermediate, std::string& value, std::string&);
+  };
+
   // Checks to run on paths.
   /**
    * @brief Check if a path is not empty.


### PR DESCRIPTION
@Schmluk turns out there isn't a `std::filesystem` function that handles expanding out the tilde, so this seems pretty generally useful