### PR TITLE
don't parse negative values as flags

### DIFF
--- a/config_utilities/src/commandline.cpp
+++ b/config_utilities/src/commandline.cpp
@@ -37,6 +37,7 @@
 
 #include <filesystem>
 #include <sstream>
+#include <regex>
 
 #include "config_utilities/internal/logger.h"
 #include "config_utilities/internal/yaml_utils.h"
@@ -86,10 +87,14 @@ std::string Span::extractTokens(int argc, char* argv[]) const {
 }
 
 std::optional<Span> getSpan(int argc, char* argv[], int pos, bool parse_all, std::string& error) {
+  std::regex flag_regex(R"regex(^-{1,2}[\w-]+)regex");
+
   int index = pos + 1;
   while (index < argc) {
     const std::string curr_opt = argv[index];
-    const bool is_flag = !curr_opt.empty() && curr_opt[0] == '-';
+
+    std::smatch m;
+    const bool is_flag = std::regex_match(curr_opt, m, flag_regex);
     if (is_flag) {
       break;  // stop parsing the span
     }

--- a/config_utilities/test/tests/commandline.cpp
+++ b/config_utilities/test/tests/commandline.cpp
@@ -250,4 +250,19 @@ TEST(Commandline, ShortOpt) {
   EXPECT_EQ(args.get_cmd(), "some_command -h");
 }
 
+TEST(Commandline, EqualOpt) {
+  // Check that short options still break parsing
+  CliArgs cli_args(std::vector<std::string>{"some_command",
+                                            "--config-utilities-yaml",
+                                            "{c:",
+                                            "6.0, a:",
+                                            "-7.0}",
+                                            "--some-arg=value}"});
+  auto args = cli_args.get();
+  const auto node = internal::loadFromArguments(args.argc, args.argv, true);
+  const auto expected = YAML::Load(R"yaml({c: 6.0, a: -7.0})yaml");
+  expectEqual(expected, node);
+  EXPECT_EQ(args.get_cmd(), "some_command --some-arg=value}");
+}
+
 }  // namespace config::test

--- a/config_utilities/test/tests/commandline.cpp
+++ b/config_utilities/test/tests/commandline.cpp
@@ -216,9 +216,38 @@ a: 6.0
 b: [4]
 d: world!
   )yaml");
-  std::cerr << node << std::endl;
   expectEqual(expected, node);
   EXPECT_EQ(args.get_cmd(), "some_command --verbose=true --some-flag --ros-args -r other_arg:=something");
+}
+
+TEST(Commandline, NegativeValue) {
+  // Checks that we correctly don't detect negative values as flags
+  CliArgs cli_args(std::vector<std::string>{"some_command", "--config-utilities-yaml", "{c:", "6.0, a:", "-7.0}"});
+  auto args = cli_args.get();
+  const auto node = internal::loadFromArguments(args.argc, args.argv, true);
+  const auto expected = YAML::Load(R"yaml({c: 6.0, a: -7.0})yaml");
+  expectEqual(expected, node);
+  EXPECT_EQ(args.get_cmd(), "some_command");
+}
+
+TEST(Commandline, ShortOpt) {
+  // Checks that we correctly don't detect negative values as flags
+  CliArgs cli_args(std::vector<std::string>{"some_command",
+                                            "--config-utilities-yaml",
+                                            "{c:",
+                                            "6.0, a:",
+                                            "-7.0}",
+                                            "-h",
+                                            "--config-utilities-yaml",
+                                            "{c:",
+                                            "-h,",
+                                            "a:",
+                                            "9.0}"});
+  auto args = cli_args.get();
+  const auto node = internal::loadFromArguments(args.argc, args.argv, true);
+  const auto expected = YAML::Load(R"yaml({c: '-h', a: 9.0})yaml");
+  expectEqual(expected, node);
+  EXPECT_EQ(args.get_cmd(), "some_command -h");
 }
 
 }  // namespace config::test

--- a/config_utilities/test/tests/commandline.cpp
+++ b/config_utilities/test/tests/commandline.cpp
@@ -231,7 +231,7 @@ TEST(Commandline, NegativeValue) {
 }
 
 TEST(Commandline, ShortOpt) {
-  // Checks that we correctly don't detect negative values as flags
+  // Check that short options still break parsing
   CliArgs cli_args(std::vector<std::string>{"some_command",
                                             "--config-utilities-yaml",
                                             "{c:",


### PR DESCRIPTION
@Schmluk just fyi ran into an issue where having something like `--config-utilities-yaml {some_value: -1}` meant that `-1}` was treated as a separate command line arg (I'm planning on merging once I confirm CI passes). I *think* the new regex covers almost all cases but there are definitely some subtleties / corner cases that I might still be missing