### PR TITLE
Feature/substitutions

### DIFF
--- a/config_utilities/CMakeLists.txt
+++ b/config_utilities/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(
   src/settings.cpp
   src/string_utils.cpp
   src/substitutions.cpp
+  src/substitution_parsers.cpp
   src/validation.cpp
   src/visitor.cpp
   src/yaml_parser.cpp

--- a/config_utilities/CMakeLists.txt
+++ b/config_utilities/CMakeLists.txt
@@ -39,7 +39,7 @@ add_library(
   src/path.cpp
   src/settings.cpp
   src/string_utils.cpp
-  src/tag_processors.cpp
+  src/substitutions.cpp
   src/validation.cpp
   src/visitor.cpp
   src/yaml_parser.cpp

--- a/config_utilities/app/composite_configs.cpp
+++ b/config_utilities/app/composite_configs.cpp
@@ -19,6 +19,8 @@ Options:
                               '{a: {b: FILE_CONTENTS}}'. Can be specified multiple times.
   -v/--config-utilities-var: Takes a KEY=VALUE pair to add to the substitution context. Can be specified
                              multiple times.
+  -d/--disable-substitutions: Turn off substitutions resolution
+  --no-disable-substitutions: Turn substitution resolution on (currently on by default)
 
 Example:
 > echo "{a: 42, bar: hello}" > /tmp/test_in.yaml

--- a/config_utilities/app/composite_configs.cpp
+++ b/config_utilities/app/composite_configs.cpp
@@ -10,18 +10,20 @@ Invalid YAML or missing files get dropped during compositing.
 
 Options:
   -h/--help: Show this message.
-  --config-utilities-yaml: Takes an arbitrary set of tokens that form a valid YAML string.
-                           Spaces are not required to be escaped, so `--config-utilities foo: value`
-                           is parsed the same as `--config-utilities 'foo: value'`. Can be specified
-                           multiple times.
-  --config-utilities-file: Takes a filepath to YAML to load and composite. The YAML can optionally
-                           be namespaced by `@NAMESPACE` where 'FILE@a/b' maps to
-                           '{a: {b: FILE_CONTENTS}}'. Can be specified multiple times.
+  -c/--config-utilities-yaml: Takes an arbitrary set of tokens that form a valid YAML string.
+                              Spaces are not required to be escaped, so `--config-utilities foo: value`
+                              is parsed the same as `--config-utilities 'foo: value'`. Can be specified
+                              multiple times.
+  -f/--config-utilities-file: Takes a filepath to YAML to load and composite. The YAML can optionally
+                              be namespaced by `@NAMESPACE` where 'FILE@a/b' maps to
+                              '{a: {b: FILE_CONTENTS}}'. Can be specified multiple times.
+  -v/--config-utilities-var: Takes a KEY=VALUE pair to add to the substitution context. Can be specified
+                             multiple times.
 
 Example:
 > echo "{a: 42, bar: hello}" > /tmp/test_in.yaml
-> composite-configs --config-utilities-yaml "{foo: {bar: value, b: -1.0}}" --config-utilities-file /tmp/test_in.yaml@foo
-{foo: {bar: hello, b: -1.0, a: 42}}
+> composite-configs --config-utilities-yaml "{foo: {bar: value, b: -1.0, c: $<var other>}}" --config-utilities-file /tmp/test_in.yaml@foo -v other=42
+{foo: {bar: hello, b: -1.0, c: 42, a: 42}}
 
 See https://github.com/MIT-SPARK/config_utilities/blob/main/docs/Parsing.md#parse-from-the-command-line
 for more information.

--- a/config_utilities/include/config_utilities/substitution_parsers.h
+++ b/config_utilities/include/config_utilities/substitution_parsers.h
@@ -1,0 +1,58 @@
+/** -----------------------------------------------------------------------------
+ * Copyright (c) 2023 Massachusetts Institute of Technology.
+ * All Rights Reserved.
+ *
+ * AUTHORS:     Lukas Schmid <lschmid@mit.edu>, Nathan Hughes <na26933@mit.edu>
+ * AFFILIATION: MIT-SPARK Lab, Massachusetts Institute of Technology
+ * YEAR:        2023
+ * LICENSE:     BSD 3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * -------------------------------------------------------------------------- */
+
+#pragma once
+
+#include "config_utilities/substitutions.h"
+
+namespace config {
+
+/**
+ * @brief Attempts to replace `$(env VAR)` with the value of VAR from the environment
+ */
+struct EnvSubstitution : public Substitution {
+  inline static const std::string NAME = "env";
+  std::string process(const ParserContext& context, const std::string& contents) const override;
+};
+
+/**
+ * @brief Attempts to replace `$(env VAR)` with the value of VAR from the environment
+ */
+struct VarSubstitution : public Substitution {
+  inline static const std::string NAME = "var";
+  std::string process(const ParserContext& context, const std::string& contents) const override;
+};
+
+}  // namespace config

--- a/config_utilities/include/config_utilities/substitutions.h
+++ b/config_utilities/include/config_utilities/substitutions.h
@@ -59,6 +59,15 @@ struct ParserContext {
   std::string separator = R"""(\| *)""";
   //! Name-value pairs for use in substitution
   std::map<std::string, std::string> vars;
+
+  //! @brief Flag that an error was encountered in parsing
+  void error() const { error_ = true; }
+
+  //! @brief Return if an error was encountered
+  operator bool() const { return !error_; }
+
+ private:
+  mutable bool error_;
 };
 
 struct Substitution {

--- a/config_utilities/include/config_utilities/substitutions.h
+++ b/config_utilities/include/config_utilities/substitutions.h
@@ -35,6 +35,10 @@
 
 #pragma once
 
+#include <map>
+#include <memory>
+#include <string>
+
 #include <yaml-cpp/yaml.h>
 
 namespace config {
@@ -108,22 +112,6 @@ template <typename T>
 RegisteredSubstitutions::Registration<T>::Registration() {
   RegisteredSubstitutions::addEntry(T::NAME, std::make_unique<T>());
 }
-
-/**
- * @brief Attempts to replace `$(env VAR)` with the value of VAR from the environment
- */
-struct EnvSubstitution : public Substitution {
-  inline static const std::string NAME = "env";
-  std::string process(const ParserContext& context, const std::string& contents) const override;
-};
-
-/**
- * @brief Attempts to replace `$(env VAR)` with the value of VAR from the environment
- */
-struct VarSubstitution : public Substitution {
-  inline static const std::string NAME = "var";
-  std::string process(const ParserContext& context, const std::string& contents) const override;
-};
 
 /**
  * @brief Iterate through the node, resolving tags

--- a/config_utilities/include/config_utilities/substitutions.h
+++ b/config_utilities/include/config_utilities/substitutions.h
@@ -61,6 +61,8 @@ struct ParserContext {
   std::string suffix = R"""(>)""";
   //! Separator between substitution tag and substitution input
   std::string separator = R"""( *(\|| ) *)""";
+  //! Whether or not substitutions are allowed
+  bool allow_substitutions = true;
   //! Name-value pairs for use in substitution
   std::map<std::string, std::string> vars;
 

--- a/config_utilities/include/config_utilities/substitutions.h
+++ b/config_utilities/include/config_utilities/substitutions.h
@@ -56,7 +56,7 @@ struct ParserContext {
   //! Suffix for any substitution
   std::string suffix = R"""(>)""";
   //! Separator between substitution tag and substitution input
-  std::string separator = R"""( *\| *)""";
+  std::string separator = R"""( *(\|| ) *)""";
   //! Name-value pairs for use in substitution
   std::map<std::string, std::string> vars;
 
@@ -129,6 +129,6 @@ struct VarSubstitution : public Substitution {
  * @brief Iterate through the node, resolving tags
  * @param[in] node Node to resolve tags for
  */
-void resolveSubstitutions(YAML::Node node, const ParserContext& context = {});
+void resolveSubstitutions(YAML::Node node, const ParserContext& context = {}, bool strict = true);
 
 }  // namespace config

--- a/config_utilities/include/config_utilities/substitutions.h
+++ b/config_utilities/include/config_utilities/substitutions.h
@@ -56,7 +56,7 @@ struct ParserContext {
   //! Suffix for any substitution
   std::string suffix = R"""(>)""";
   //! Separator between substitution tag and substitution input
-  std::string separator = R"""(\| *)""";
+  std::string separator = R"""( *\| *)""";
   //! Name-value pairs for use in substitution
   std::map<std::string, std::string> vars;
 
@@ -67,7 +67,7 @@ struct ParserContext {
   operator bool() const { return !error_; }
 
  private:
-  mutable bool error_;
+  mutable bool error_ = false;
 };
 
 struct Substitution {
@@ -114,6 +114,14 @@ RegisteredSubstitutions::Registration<T>::Registration() {
  */
 struct EnvSubstitution : public Substitution {
   inline static const std::string NAME = "env";
+  std::string process(const ParserContext& context, const std::string& contents) const override;
+};
+
+/**
+ * @brief Attempts to replace `$(env VAR)` with the value of VAR from the environment
+ */
+struct VarSubstitution : public Substitution {
+  inline static const std::string NAME = "var";
   std::string process(const ParserContext& context, const std::string& contents) const override;
 };
 

--- a/config_utilities/src/commandline.cpp
+++ b/config_utilities/src/commandline.cpp
@@ -216,8 +216,7 @@ CliParser& CliParser::parse(int& argc, char* argv[], bool remove_args) {
     if (curr_opt == "--" && !found_separator) {
       found_separator = true;
       spans.emplace_back(Span{i, 0, curr_opt});
-      ++i;
-      continue;
+      break;
     }
 
     const auto opt_match = matches(curr_opt);

--- a/config_utilities/src/commandline.cpp
+++ b/config_utilities/src/commandline.cpp
@@ -41,7 +41,7 @@
 
 #include "config_utilities/internal/logger.h"
 #include "config_utilities/internal/yaml_utils.h"
-#include "config_utilities/tag_processors.h"
+#include "config_utilities/substitutions.h"
 
 namespace config::internal {
 
@@ -272,7 +272,7 @@ YAML::Node loadFromArguments(int& argc, char* argv[], bool remove_args, ParserIn
     internal::mergeYamlNodes(node, parsed_node, MergeMode::APPEND);
   }
 
-  resolveTags(node);
+  resolveSubstitutions(node);
   return node;
 }
 

--- a/config_utilities/src/substitution_parsers.cpp
+++ b/config_utilities/src/substitution_parsers.cpp
@@ -1,0 +1,72 @@
+/** -----------------------------------------------------------------------------
+ * Copyright (c) 2023 Massachusetts Institute of Technology.
+ * All Rights Reserved.
+ *
+ * AUTHORS:     Lukas Schmid <lschmid@mit.edu>, Nathan Hughes <na26933@mit.edu>
+ * AFFILIATION: MIT-SPARK Lab, Massachusetts Institute of Technology
+ * YEAR:        2023
+ * LICENSE:     BSD 3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * -------------------------------------------------------------------------- */
+
+#include "config_utilities/substitution_parsers.h"
+
+#include <cstdlib>
+
+#include "config_utilities/internal/logger.h"
+
+namespace config {
+namespace {
+
+static const auto env_reg = RegisteredSubstitutions::Registration<EnvSubstitution>();
+static const auto var_reg = RegisteredSubstitutions::Registration<VarSubstitution>();
+
+}  // namespace
+
+std::string EnvSubstitution::process(const ParserContext& context, const std::string& contents) const {
+  const auto ret = std::getenv(contents.c_str());
+  if (!ret) {
+    context.error();
+    internal::Logger::logError("Failed to get envname from '" + contents + "'");
+    return contents;
+  }
+
+  return std::string(ret);
+}
+
+std::string VarSubstitution::process(const ParserContext& context, const std::string& contents) const {
+  auto iter = context.vars.find(contents);
+  if (iter == context.vars.end()) {
+    internal::Logger::logError("Unknown var '" + contents + "'");
+    context.error();
+    return contents;
+  }
+
+  return iter->second;
+}
+
+}  // namespace config

--- a/config_utilities/src/substitutions.cpp
+++ b/config_utilities/src/substitutions.cpp
@@ -208,6 +208,10 @@ inline SubsNode parseSubstitutions(const ParserContext& context, const std::stri
 }
 
 inline void resolveSubstitution(YAML::Node node, const ParserContext& context) {
+  if (!context.allow_substitutions) {
+    return;
+  }
+
   if (!node.IsScalar()) {
     return;
   }

--- a/config_utilities/src/substitutions.cpp
+++ b/config_utilities/src/substitutions.cpp
@@ -35,16 +35,12 @@
 
 #include "config_utilities/substitutions.h"
 
-#include <cstdlib>
 #include <regex>
 
 #include "config_utilities/internal/logger.h"
 
 namespace config {
 namespace {
-
-static const auto env_reg = RegisteredSubstitutions::Registration<EnvSubstitution>();
-static const auto var_reg = RegisteredSubstitutions::Registration<VarSubstitution>();
 
 class SubsNode {
  public:
@@ -287,28 +283,6 @@ void RegisteredSubstitutions::addEntry(const std::string& tag, std::unique_ptr<S
   if (!had_prev) {
     internal::Logger::logWarning("Dropping new processor for existing tag '" + tag + "'");
   }
-}
-
-std::string EnvSubstitution::process(const ParserContext& context, const std::string& contents) const {
-  const auto ret = std::getenv(contents.c_str());
-  if (!ret) {
-    context.error();
-    internal::Logger::logError("Failed to get envname from '" + contents + "'");
-    return contents;
-  }
-
-  return std::string(ret);
-}
-
-std::string VarSubstitution::process(const ParserContext& context, const std::string& contents) const {
-  auto iter = context.vars.find(contents);
-  if (iter == context.vars.end()) {
-    internal::Logger::logError("Unknown var '" + contents + "'");
-    context.error();
-    return contents;
-  }
-
-  return iter->second;
 }
 
 void resolveSubstitutions(YAML::Node node, const ParserContext& context, bool strict) {

--- a/config_utilities/src/substitutions.cpp
+++ b/config_utilities/src/substitutions.cpp
@@ -33,40 +33,63 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * -------------------------------------------------------------------------- */
 
-#include "config_utilities/tag_processors.h"
+#include "config_utilities/substitutions.h"
 
 #include <cstdlib>
 #include <sstream>
+#include <regex>
 
 #include "config_utilities/internal/logger.h"
 
 namespace config {
 namespace {
 
-static const auto env_registration = RegisteredTags::Registration<EnvTag>("!env");
+static const auto env_reg = RegisteredSubstitutions::Registration<EnvSubstitution>();
 
-inline void resolveTag(YAML::Node node) {
+inline void resolveSubstitution(YAML::Node node) {
   const auto tag = node.Tag();
   if (tag == "!append" || tag == "!update" || tag == "!replace") {
     node.SetTag("");
+  }
+
+  if (!node.IsScalar()) {
     return;
   }
 
-  auto parser = RegisteredTags::getEntry(tag);
-  if (!parser) {
+  std::string result;
+
+  bool has_match = false;
+  auto to_search = node.as<std::string>();
+  std::regex regex(R"""($\((\w+) (.+)\))""");
+  for (std::smatch m; std::regex_search(to_search, m, regex);) {
+    const std::string subs_name = m[1];
+    auto parser = RegisteredSubstitutions::getEntry(subs_name);
+    if (!parser) {
+      internal::Logger::logWarning("Unknown substitution '" + subs_name + "'!");
+      continue;
+    }
+
+    result += m.prefix();
+    result += parser->process(m[2]);
+    to_search = m.suffix();
+  }
+
+  // TODO(nathan) handle unmatched suffix
+
+  if (!has_match) {
     return;
   }
 
-  parser->processNode(node);
+  node = result;
 }
 
 }  // namespace
 
-std::unique_ptr<RegisteredTags> RegisteredTags::s_instance_ = nullptr;
+std::unique_ptr<RegisteredSubstitutions> RegisteredSubstitutions::s_instance_ = nullptr;
 
-RegisteredTags::RegisteredTags() = default;
+RegisteredSubstitutions::RegisteredSubstitutions() = default;
 
-const TagProcessor* RegisteredTags::getEntry(const std::string& tag) {
+const Substitution* RegisteredSubstitutions::getEntry(const std::string& tag) {
   auto& curr = instance();
   auto iter = curr.entries_.find(tag);
   if (iter == curr.entries_.end()) {
@@ -76,15 +99,15 @@ const TagProcessor* RegisteredTags::getEntry(const std::string& tag) {
   }
 }
 
-RegisteredTags& RegisteredTags::instance() {
+RegisteredSubstitutions& RegisteredSubstitutions::instance() {
   if (!s_instance_) {
-    s_instance_.reset(new RegisteredTags());
+    s_instance_.reset(new RegisteredSubstitutions());
   }
 
   return *s_instance_;
 }
 
-void RegisteredTags::addEntry(const std::string& tag, std::unique_ptr<TagProcessor>&& proc) {
+void RegisteredSubstitutions::addEntry(const std::string& tag, std::unique_ptr<Substitution>&& proc) {
   auto& curr = instance();
   auto had_prev = curr.entries_.emplace(tag, std::move(proc)).second;
   if (!had_prev) {
@@ -92,7 +115,7 @@ void RegisteredTags::addEntry(const std::string& tag, std::unique_ptr<TagProcess
   }
 }
 
-void EnvTag::processNode(YAML::Node node) const {
+void EnvSubstitution::process(YAML::Node node) const {
   if (!node.IsScalar()) {
     std::stringstream ss;
     ss << "Node with !env tag is not scalar: '" << node << "'";
@@ -122,22 +145,22 @@ void EnvTag::processNode(YAML::Node node) const {
   node.SetTag("");
 }
 
-void resolveTags(YAML::Node node) {
-  resolveTag(node);
+void resolveSubstitutions(YAML::Node node) {
+  resolveSubstitution(node);
   switch (node.Type()) {
     case YAML::NodeType::Map:
       for (const auto& child : node) {
         // technically keys can have tags...
         // shouldn't need to recurse
-        resolveTag(child.first);
+        resolveSubstitution(child.first);
         // dispatch recursion to value
-        resolveTags(child.second);
+        resolveSubstitutions(child.second);
       }
       break;
     case YAML::NodeType::Sequence:
       // dispatch resolution to all children
       for (const auto& child : node) {
-        resolveTags(child);
+        resolveSubstitutions(child);
       }
       break;
     case YAML::NodeType::Undefined:

--- a/config_utilities/src/substitutions.cpp
+++ b/config_utilities/src/substitutions.cpp
@@ -115,34 +115,16 @@ void RegisteredSubstitutions::addEntry(const std::string& tag, std::unique_ptr<S
   }
 }
 
-void EnvSubstitution::process(YAML::Node node) const {
-  if (!node.IsScalar()) {
-    std::stringstream ss;
-    ss << "Node with !env tag is not scalar: '" << node << "'";
-    internal::Logger::logWarning(ss.str());
-    return;
-  }
-
-  std::string varname;
-  try {
-    varname = node.as<std::string>();
-  } catch (YAML::Exception& e) {
-    std::stringstream ss;
-    ss << "Failed to get envname from '" << node << "'";
-    internal::Logger::logWarning(ss.str());
-    return;
-  }
-
-  const auto ret = std::getenv(varname.c_str());
+std::string EnvSubstitution::process(const std::string& contents) const {
+  const auto ret = std::getenv(contents.c_str());
   if (!ret) {
     std::stringstream ss;
-    ss << "Failed to get envname from '" << node << "'";
+    ss << "Failed to get envname from '" << contents << "'";
     internal::Logger::logWarning(ss.str());
-    return;
+    return contents;
   }
 
-  node = std::string(ret);
-  node.SetTag("");
+  return std::string(ret);
 }
 
 void resolveSubstitutions(YAML::Node node) {

--- a/config_utilities/test/CMakeLists.txt
+++ b/config_utilities/test/CMakeLists.txt
@@ -50,7 +50,7 @@ add_executable(
   tests/path.cpp
   tests/string_utils.cpp
   tests/subconfigs.cpp
-  tests/tag_processors.cpp
+  tests/substitutions.cpp
   tests/traits.cpp
   tests/update.cpp
   tests/validity_checks.cpp

--- a/config_utilities/test/tests/commandline.cpp
+++ b/config_utilities/test/tests/commandline.cpp
@@ -303,4 +303,14 @@ TEST(Commandline, InvalidVariable) {
   EXPECT_EQ(args.get_cmd(), "some_command");
 }
 
+TEST(Commandline, SeparatorCorrect) {
+  // Checks that we stop processing options after a separator
+  CliArgs cli_args(std::vector<std::string>{"some_command", "-c", "{c: ", "$<var", "c>}", "-v", "c=5", "--", "-v", "c=6"});
+  auto args = cli_args.get();
+  const auto node = internal::loadFromArguments(args.argc, args.argv, true);
+  const auto expected = YAML::Load(R"yaml({c: 5})yaml");
+  expectEqual(expected, node);
+  EXPECT_EQ(args.get_cmd(), "some_command -v c=6");
+}
+
 }  // namespace config::test

--- a/config_utilities/test/tests/commandline.cpp
+++ b/config_utilities/test/tests/commandline.cpp
@@ -265,4 +265,24 @@ TEST(Commandline, EqualOpt) {
   EXPECT_EQ(args.get_cmd(), "some_command --some-arg=value}");
 }
 
+TEST(Commandline, VariableOpts) {
+  // Checks that we correctly parse and use variables for substitutions
+  CliArgs cli_args(std::vector<std::string>{"some_command", "-c", "{c: ", "$<var", "c>}", "-v", "c=5"});
+  auto args = cli_args.get();
+  const auto node = internal::loadFromArguments(args.argc, args.argv, true);
+  const auto expected = YAML::Load(R"yaml({c: 5})yaml");
+  expectEqual(expected, node);
+  EXPECT_EQ(args.get_cmd(), "some_command");
+}
+
+TEST(Commandline, InvalidVariable) {
+  // Checks that we reject invalid variables
+  CliArgs cli_args(std::vector<std::string>{"some_command", "-c", "{c: ", "$<var", "c>}", "-v", "c=5", "-v", "c:6"});
+  auto args = cli_args.get();
+  const auto node = internal::loadFromArguments(args.argc, args.argv, true);
+  const auto expected = YAML::Load(R"yaml({c: 5})yaml");
+  expectEqual(expected, node);
+  EXPECT_EQ(args.get_cmd(), "some_command");
+}
+
 }  // namespace config::test

--- a/config_utilities/test/tests/substitutions.cpp
+++ b/config_utilities/test/tests/substitutions.cpp
@@ -83,7 +83,7 @@ TEST(Substitutions, resolveEnv) {
   {  // check that we don't try to pass non-scalars to getenv
     const auto node = YAML::Load("root: $<env|[1, 2, 3]>");
     const auto result = doResolve(node);
-    const auto expected = YAML::Load("root: [1, 2, 3]");
+    const auto expected = YAML::Load("root: $<env|[1, 2, 3]>");
     expectEqual(result, expected);
   }
 
@@ -104,6 +104,15 @@ TEST(Substitutions, resolveEnv) {
     const auto node = YAML::Load("root: $<env|HOME>");
     const auto result = doResolve(node);
     const auto expected = YAML::Load("root: " + std::string(set));
+    expectEqual(result, expected);
+  }
+}
+
+TEST(Substitutions, interpolateEnv) {
+  {  // check that we don't try to pass non-scalars to getenv
+    const auto node = YAML::Load("root: $<env|[1, 2, 3]>");
+    const auto result = doResolve(node);
+    const auto expected = YAML::Load("root: $<env|[1, 2, 3]>");
     expectEqual(result, expected);
   }
 }

--- a/config_utilities/test/tests/substitutions.cpp
+++ b/config_utilities/test/tests/substitutions.cpp
@@ -81,7 +81,7 @@ root:
 
 TEST(Substitutions, resolveEnv) {
   {  // check that we don't try to pass non-scalars to getenv
-    const auto node = YAML::Load("root: !env [1, 2, 3]");
+    const auto node = YAML::Load("root: $<env|[1, 2, 3]>");
     const auto result = doResolve(node);
     const auto expected = YAML::Load("root: [1, 2, 3]");
     expectEqual(result, expected);
@@ -91,9 +91,9 @@ TEST(Substitutions, resolveEnv) {
   if (unset) {
     FAIL() << "environment variable '/some/random/env/variable' is set";
   } else {
-    const auto node = YAML::Load("root: !env /some/random/env/variable");
+    const auto node = YAML::Load("root: $<env|/some/random/env/variable>");
     const auto result = doResolve(node);
-    const auto expected = YAML::Load("root: /some/random/env/variable");
+    const auto expected = YAML::Load("root: $<env|/some/random/env/variable>");
     expectEqual(result, expected);
   }
 
@@ -101,7 +101,7 @@ TEST(Substitutions, resolveEnv) {
   if (!set) {
     FAIL() << "required environment variable 'HOME' not set";
   } else {
-    const auto node = YAML::Load("root: !env HOME");
+    const auto node = YAML::Load("root: $<env|HOME>");
     const auto result = doResolve(node);
     const auto expected = YAML::Load("root: " + std::string(set));
     expectEqual(result, expected);

--- a/config_utilities/test/tests/substitutions.cpp
+++ b/config_utilities/test/tests/substitutions.cpp
@@ -33,10 +33,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * -------------------------------------------------------------------------- */
 
-#include "config_utilities/tag_processors.h"
-
 #include <gtest/gtest.h>
 
+#include "config_utilities/substitutions.h"
 #include "config_utilities/test/utils.h"
 
 namespace config::test {
@@ -45,13 +44,13 @@ namespace {
 
 inline YAML::Node doResolve(const YAML::Node& orig) {
   auto result = YAML::Clone(orig);
-  resolveTags(result);
+  resolveSubstitutions(result);
   return result;
 }
 
 }  // namespace
 
-TEST(YamlUtils, resolveLeftoverTags) {
+TEST(Substitutions, clearLeftoverTags) {
   const auto node = YAML::Load(R"""(
 root:
   children:
@@ -80,7 +79,7 @@ root:
   expectEqual(result, expected);
 }
 
-TEST(YamlUtils, resolveEnvTags) {
+TEST(Substitutions, resolveEnv) {
   {  // check that we don't try to pass non-scalars to getenv
     const auto node = YAML::Load("root: !env [1, 2, 3]");
     const auto result = doResolve(node);

--- a/config_utilities/test/tests/substitutions.cpp
+++ b/config_utilities/test/tests/substitutions.cpp
@@ -33,18 +33,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * -------------------------------------------------------------------------- */
 
+#include "config_utilities/substitutions.h"
+
 #include <gtest/gtest.h>
 
-#include "config_utilities/substitutions.h"
 #include "config_utilities/test/utils.h"
 
 namespace config::test {
 
 namespace {
 
-inline YAML::Node doResolve(const YAML::Node& orig) {
+inline YAML::Node doResolve(const YAML::Node& orig, const std::map<std::string, std::string>& args = {}) {
   auto result = YAML::Clone(orig);
-  resolveSubstitutions(result);
+  ParserContext context;
+  context.vars = args;
+  resolveSubstitutions(result, context);
   return result;
 }
 
@@ -81,9 +84,9 @@ root:
 
 TEST(Substitutions, resolveEnv) {
   {  // check that we don't try to pass non-scalars to getenv
-    const auto node = YAML::Load("root: $<env|[1, 2, 3]>");
+    const auto node = YAML::Load("root: $<env | [1, 2, 3]>");
     const auto result = doResolve(node);
-    const auto expected = YAML::Load("root: $<env|[1, 2, 3]>");
+    const auto expected = YAML::Load("root: $<env | [1, 2, 3]>");
     expectEqual(result, expected);
   }
 
@@ -91,9 +94,9 @@ TEST(Substitutions, resolveEnv) {
   if (unset) {
     FAIL() << "environment variable '/some/random/env/variable' is set";
   } else {
-    const auto node = YAML::Load("root: $<env|/some/random/env/variable>");
+    const auto node = YAML::Load("root: $<env | /some/random/env/variable>");
     const auto result = doResolve(node);
-    const auto expected = YAML::Load("root: $<env|/some/random/env/variable>");
+    const auto expected = YAML::Load("root: $<env | /some/random/env/variable>");
     expectEqual(result, expected);
   }
 
@@ -101,7 +104,7 @@ TEST(Substitutions, resolveEnv) {
   if (!set) {
     FAIL() << "required environment variable 'HOME' not set";
   } else {
-    const auto node = YAML::Load("root: $<env|HOME>");
+    const auto node = YAML::Load("root: $<env | HOME>");
     const auto result = doResolve(node);
     const auto expected = YAML::Load("root: " + std::string(set));
     expectEqual(result, expected);
@@ -109,12 +112,11 @@ TEST(Substitutions, resolveEnv) {
 }
 
 TEST(Substitutions, interpolateEnv) {
-  {  // check that we don't try to pass non-scalars to getenv
-    const auto node = YAML::Load("root: $<env|[1, 2, 3]>");
-    const auto result = doResolve(node);
-    const auto expected = YAML::Load("root: $<env|[1, 2, 3]>");
-    expectEqual(result, expected);
-  }
+  std::map<std::string, std::string> args{{"foo", "a"}, {"bar", "b"}};
+  const auto node = YAML::Load("root: other/$<var | foo>/test a/$<var | bar>/c");
+  const auto result = doResolve(node, args);
+  const auto expected = YAML::Load("root: other/a/test a/b/c");
+  expectEqual(result, expected);
 }
 
 }  // namespace config::test

--- a/docs/Compositing.md
+++ b/docs/Compositing.md
@@ -1,0 +1,69 @@
+# Compositing multiple YAML sources
+
+**Contents:**
+- [Compositing](#compositing)
+- [How compositing works](#how-compositing-works)
+- [Controlling compositing behavior](#controlling-compositing-behavior)
+- [Substitutions](#substitutions)
+
+## Compositing
+
+`config_utilities` includes a command line tool that will take multiple sources of YAML and dump the combined (composited) YAML to `stdout`. This is designed for the use-case where a base YAML file contains the majority of a configuration, and small overlays are used to adapt or fill in the configuration for different variants of a system.
+
+You can run `composite-configs -h` for more information on the utility.
+
+## How compositing works
+
+This tutorial explains how different sources of YAML data are combined into a single YAML tree, and is primarily a more in-depth explanation of the behavior of the command line based YAML parser.
+Functionally, the command line parser is doing the following after parsing the various command line options.
+
+```cpp
+std::vector<YAML::Node> inputs; // parsed YAML from either files or raw YAML strings
+
+YAML::Node combined; // result YAML node
+for (const auto& input : inputs) {
+  internal::mergeYamlNodes(combined, input, MergeMode::APPEND);
+}
+```
+
+## Controlling compositing behavior
+
+The default ROS-like merging behavior (append) can be overridden by inline tags. The following behaviors are currently available:
+  - `!append`: Matched sequences are appended together (specifically, the right sequence is appended to the left)
+  - `!replace`: Matched keys result in the right key overriding the left
+  - `!merge`: Matched keys (including sequence indices) are recursed into. Any unmatched keys are added
+
+These merging behaviors apply to all children below the tag (until another tag is present).
+
+Example behavior:
+```yaml
+# original YAML (left)
+root: {child: {a: 42, c: 0}, numbers: [1, 2, 3], scalar: -1}
+# new YAML to merge (right)
+root: !TAG {child: {a: 12, b: 13}, numbers: [4, 5], other: temp}
+
+# result of merging right into left with !append in place of !TAG
+root: {child: {a: 12, c: 0, b: 13}, numbers: [1, 2, 3, 4, 5], scalar: -1, other: temp}
+# result of merging right into left with !replace in place of !TAG
+root: {child: {a: 12, b: 13}, numbers: [4, 5], scalar: -1, other: temp}
+# result of merging right into left with !merge in place of !TAG
+root: {child: {a: 12, c: 0, b: 13}, numbers: [4, 5, 3], scalar: -1, other: temp}
+```
+
+## Substitutions
+
+We also support a substitution language for interpolating values into YAML data.
+These (closely) resemble the ROS substitution language.
+Substitutions are performed with respect to a context that may have some variables that can be used.
+
+As an example, resolving substitutions in the following YAML (with the context `num_prints = 5`)
+```yaml
+input_filepath: $<env HOME>/some/random/file
+num_prints: $<var num_prints>
+```
+would result in
+```yaml
+input_filepath: /home/user/some/random/file
+num_prints: 5
+```
+after calling `resolveSubstitutions` on the parsed YAML.

--- a/docs/Parsing.md
+++ b/docs/Parsing.md
@@ -94,10 +94,11 @@ std::unique_ptr<MyBase> object = createFromRosWithNamespace<MyBase>(nh, ns);
 ## Parse from the command line
 
 It is also possible to use the same interfaces as in the yaml or ROS case but via aggregate YAML read from the command line. To use it, include `parsing/command_line.h`.
-`config_utilities` supports parsing two command line flags:
+`config_utilities` supports parsing the following command line flags:
   - `--config-utilities-file SOME_FILE_PATH`: Specify a file to load YAML from.
   - `--config-utilities-yaml SOME_ARBITRARY_YAML`: Specify YAML directly from the command line.
   - `--config-utilities-var KEY=VALUE`: Specify a new variable for the substitution context.
+  - `--disable-substitutions/--no-disable-substitutions`: Turn off resolving substitutions
 
 > **✅ Supports**<br>
 > Note that the `--config-utilities-file` flag allows for a namespace (i.e., `some/custom/ns`) to apply to the file globally. This is specified as `--config-utilities-file SOME_FILE@some/custom/ns`.

--- a/docs/Parsing.md
+++ b/docs/Parsing.md
@@ -9,7 +9,7 @@ This tutorial explains how to create configs and other objects from source data.
 
 ## Parse from yaml
 
-To support parsing from yaml nodes and files, the `parsing/yaml.h` header needs to be included. Note that [yaml-cpp](https://github.com/jbeder/yaml-cpp) is already an internal dependecy of `config_utilities`, so no additional dependencies are required. `config_utilities` expects yaml files of the format:
+To support parsing from yaml nodes and files, the `parsing/yaml.h` header needs to be included. Note that [yaml-cpp](https://github.com/jbeder/yaml-cpp) is already an internal dependency of `config_utilities`, so no additional dependencies are required. `config_utilities` expects yaml files of the format:
 ```yaml
 namespace:
   field_name: field_value
@@ -97,6 +97,7 @@ It is also possible to use the same interfaces as in the yaml or ROS case but vi
 `config_utilities` supports parsing two command line flags:
   - `--config-utilities-file SOME_FILE_PATH`: Specify a file to load YAML from.
   - `--config-utilities-yaml SOME_ARBITRARY_YAML`: Specify YAML directly from the command line.
+  - `--config-utilities-var KEY=VALUE`: Specify a new variable for the substitution context.
 
 > **✅ Supports**<br>
 > Note that the `--config-utilities-file` flag allows for a namespace (i.e., `some/custom/ns`) to apply to the file globally. This is specified as `--config-utilities-file SOME_FILE@some/custom/ns`.
@@ -104,6 +105,7 @@ It is also possible to use the same interfaces as in the yaml or ROS case but vi
 Both command line flags can be specified as many times as needed.
 When aggregating the YAML from the command line, the various flags are merged left to right (where conflicting keys from the last specified flag take precedence) and any sequences are appended together.
 For those familiar with how the ROS parameter server works, this is the same behavior.
+See [here](Compositing.md#controlling-compositing-behavior) for an in-depth discussion of options as to how to control this behavior.
 Please also note that the `--config-utilities-yaml` currently accepts multiple space-delimited tokens (because the ROS2 launch file infrastructure does not currently correctly handle escaped substitutions), so
 ```
 some_command --config-utilities-yaml '{my: {cool: config}}' --config-utilities-file some_file.yaml
@@ -128,27 +130,6 @@ int main(int argc, char** argv) {
 }
 ```
 
-The default ROS-like merging behavior can be overriden by inline tags. The following behaviors are currently available:
-  - `!append`: Matched sequences are appended together (specifically, the right sequence is appended to the left)
-  - `!replace`: Matched keys result in the right key overriding the left
-  - `!merge`: Matched keys (including sequence indices) are recursed into. Any unmatched keys are added
-
-These merging behaviors apply to all children below the tag (until another tag is present).
-
-Example behavior:
-```yaml
-# original YAML (left)
-root: {child: {a: 42, c: 0}, numbers: [1, 2, 3], scalar: -1}
-# new YAML to merge (right)
-root: !TAG {child: {a: 12, b: 13}, numbers: [4, 5], other: temp}
-
-# result of merging right into left with !append in place of !TAG
-root: {child: {a: 12, c: 0, b: 13}, numbers: [1, 2, 3, 4, 5], scalar: -1, other: temp}
-# result of merging right into left with !replace in place of !TAG
-root: {child: {a: 12, b: 13}, numbers: [4, 5], scalar: -1, other: temp}
-# result of merging right into left with !merge in place of !TAG
-root: {child: {a: 12, c: 0, b: 13}, numbers: [4, 5, 3], scalar: -1, other: temp}
-```
 
 # Parse via global context
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,20 +29,27 @@ The following tutorials will guide you through functionalities of `config_utilit
     - [Creating objects with individual configs](Factories.md#creating-objects-with-individual-configs)
     - [Delayed object creation with virtual configs](Factories.md#delayed-object-creation-with-virtual-configs)
 
-6. [**Advanced features**](Advanced.md)
+6. [**Compositing data sources**](Compositing.md)
+    - [Compositing](Compositing.md#compositing)
+    - [How compositing works](Compositing.md#how-compositing-works)
+    - [Controlling compositing behavior](Compositing.md#controlling-compositing-behavior)
+    - [Substitutions](Compositing.md#substitutions)
+
+7. [**Advanced features**](Advanced.md)
     - [Adding custom types](Advanced.md#adding-custom-types)
     - [Adding custom conversions](Advanced.md#adding-custom-conversions)
     - [Adding custom checks](Advanced.md#adding-custom-checks)
     - [Adding custom loggers](Advanced.md#adding-custom-loggers)
     - [Adding custom formatters](Advanced.md#adding-custom-formatters)
     - [Adding custom parsers](Advanced.md#adding-custom-parsers)
+    - [Adding custom substitutions](Advanced.md#adding-custom-substitutions)
 
-7. [**External Plugins**](External.md)
+8. [**External Plugins**](External.md)
     - [Loading an external library](External.md#loading-an-external-library)
     - [Managed instances](External.md#managed-instances)
     - [Debugging](External.md#debugging)
 
-8. [**Varia**](Varia.md)
+9. [**Varia**](Varia.md)
     - [Settings](Varia.md#settings)
     - [Globals](Varia.md#globals)
 


### PR DESCRIPTION
Needed to write an actual substitution parser and grammar earlier than planned because the environment variables substitution didn't work for our use-case.  @GoldenZephyr tagging you as a reviewer to get your take on the documentation and usage.

Given some mapping `{foo: bar, bar: 3}`, we can process
```yaml
root: $<env HOME>/some/path/img_00$<var  $<var foo>>.png
```
to get
```yaml
root: /home/user/some/path/img_003.png
```

Also adds short options for the command line interface (`-c` for `--config-utilities-yaml`, `-f` for `--config-utilities-file`, or `-v` for `--config-utilities-var`). I expanded out the documentation a little, hopefully it's understandable.

I think I'm about ready to add ros2 examples and documentation, but will wait until the dynamic config stuff is actually in