### PR TITLE
add utility functions to initialize setting struct

### DIFF
--- a/config_utilities/include/config_utilities/parsing/commandline.h
+++ b/config_utilities/include/config_utilities/parsing/commandline.h
@@ -187,4 +187,19 @@ std::unique_ptr<BaseT> createFromCLIWithNamespace(const std::vector<std::string>
   return internal::ObjectWithConfigFactory<BaseT, ConstructorArguments...>::create(ns_node, std::move(args)...);
 }
 
+/**
+ * @brief Create a derived type object based on collated YAML data specified via the command line
+ * @param argv Vector of command line arguments
+ * @param name_space Optional namespace to use for parsing settings
+ */
+void setConfigSettingsFromCLI(const std::vector<std::string>& argv, const std::string& name_space = "");
+
+/**
+ * @brief Create a derived type object based on collated YAML data specified via the command line
+ * @param argc Command line argument count
+ * @param argv Command line arguments
+ * @param name_space Optional namespace to use for parsing settings
+ */
+void setConfigSettingsFromCLI(int argc, char* argv[], const std::string& name_space);
+
 }  // namespace config

--- a/config_utilities/include/config_utilities/parsing/context.h
+++ b/config_utilities/include/config_utilities/parsing/context.h
@@ -109,4 +109,10 @@ std::unique_ptr<BaseT> createFromContextWithNamespace(const std::string& name_sp
   return internal::Context::createNamespaced<BaseT, ConstructorArguments...>(name_space, args...);
 }
 
+/**
+ * @brief Load global settings for `config_utilities` from current parsed context
+ * @param name_space Namespace to load the settings from
+ */
+void setConfigSettingsFromContext(const std::string& name_space = "");
+
 }  // namespace config

--- a/config_utilities/include/config_utilities/parsing/yaml.h
+++ b/config_utilities/include/config_utilities/parsing/yaml.h
@@ -210,4 +210,13 @@ bool updateFromYaml(ConfigT& config, const YAML::Node& node, const std::string& 
   return updateFields(config, node, true, name_space);
 }
 
+/**
+ * @brief Load global settings for `config_utilities` from YAML
+ * @param node YAML node containing settings
+ * @param name_space Namespace to load the settings from
+ */
+inline void setConfigSettingsFromYAML(const YAML::Node& node, const std::string& name_space = "") {
+  internal::Visitor::setValues(Settings(), internal::lookupNamespace(node, name_space), true);
+}
+
 }  // namespace config

--- a/config_utilities/src/commandline.cpp
+++ b/config_utilities/src/commandline.cpp
@@ -42,8 +42,10 @@
 #include "config_utilities/internal/logger.h"
 #include "config_utilities/internal/yaml_utils.h"
 #include "config_utilities/substitutions.h"
+#include "config_utilities/update.h"
 
-namespace config::internal {
+namespace config {
+namespace internal {
 
 namespace fs = std::filesystem;
 
@@ -385,4 +387,16 @@ YAML::Node loadFromArguments(const std::vector<std::string>& _args) {
   return loadFromArguments(argc, argv.data(), false);
 }
 
-}  // namespace config::internal
+}  // namespace internal
+
+void setConfigSettingsFromCLI(int argc, char* argv[], const std::string& name_space) {
+  auto node = internal::loadFromArguments(argc, argv, false);
+  internal::Visitor::setValues(Settings(), internal::lookupNamespace(node, name_space), true);
+}
+
+void setConfigSettingsFromCLI(const std::vector<std::string>& argv, const std::string& name_space) {
+  auto node = internal::loadFromArguments(argv);
+  internal::Visitor::setValues(Settings(), internal::lookupNamespace(node, name_space), true);
+}
+
+}  // namespace config

--- a/config_utilities/src/context.cpp
+++ b/config_utilities/src/context.cpp
@@ -37,6 +37,8 @@
 
 #include "config_utilities/internal/config_context.h"
 #include "config_utilities/parsing/commandline.h"
+#include "config_utilities/update.h"
+#include "config_utilities/settings.h"
 
 namespace config {
 
@@ -50,5 +52,10 @@ void pushToContext(const YAML::Node& node, const std::string& ns) { internal::Co
 void clearContext() { internal::Context::clear(); }
 
 YAML::Node contextToYaml() { return internal::Context::toYaml(); }
+
+void setConfigSettingsFromContext(const std::string& name_space) {
+  const auto node = internal::Context::toYaml();
+  internal::Visitor::setValues(Settings(), internal::lookupNamespace(node, name_space), true);
+}
 
 }  // namespace config


### PR DESCRIPTION
Started updating Hydra and other repos to work with the dynamic configs PR and realized there wasn't really an easy way to actually initialize `Settings` without duplicating the struct or having something like
```cpp
struct NodeSettings {
  bool exit_on_clock = true;  
  config::internal::Settings::Printing printing;
};
```
both of which seem kinda bad. I'm a little nervous about weird issues because the settings are mutating while parsing, but it looks like it _should_ be okay right now. My intention is to split the settings struct from the global settings singleton and update the settings atomically after parsing in the singleton if it becomes an issue