### PR TITLE
reuse visitField for conversions on intermediate types

### DIFF
--- a/config_utilities/include/config_utilities/config.h
+++ b/config_utilities/include/config_utilities/config.h
@@ -54,6 +54,17 @@ namespace config {
 inline void name(const std::string& name) { internal::Visitor::visitName(name); }
 
 /**
+ * @brief Set the name of a config from the template parameter type.
+ * @tparam T type to get the name from
+ *
+ * This is for cases where you may not have a static config struct name (i.e., with a templated config struct)
+ */
+template <typename T>
+void name() {
+  internal::Visitor::visitName(internal::typeName<T>());
+}
+
+/**
  * @brief Declare string-named fields of the config. This string will be used to get the configs field values during
  * creation, and for checking of validity.
  * @param field The config member that stores data.

--- a/config_utilities/include/config_utilities/internal/visitor.h
+++ b/config_utilities/include/config_utilities/internal/visitor.h
@@ -104,8 +104,8 @@ struct Visitor {
   template <typename T, typename std::enable_if<!isConfig<T>(), bool>::type = true>
   static void visitField(T& field, const std::string& field_name, const std::string& unit);
 
-  // Non-config types with a conversion.
-  template <typename Conversion, typename T, typename std::enable_if<!isConfig<T>(), bool>::type = true>
+  // Types with a extra conversion.
+  template <typename Conversion, typename T>
   static void visitField(T& field, const std::string& field_name, const std::string& unit);
 
   // Single config types.
@@ -166,11 +166,16 @@ struct Visitor {
   template <typename ConfigT, typename std::enable_if<is_virtual_config<ConfigT>::value, bool>::type = true>
   static MetaData getDefaults(const ConfigT& config);
 
-  // Dispatch getting field input info from conversions.
-  template <typename Conversion, typename std::enable_if<!hasFieldInputInfo<Conversion>(), bool>::type = true>
-  static FieldInputInfo::Ptr getFieldInputInfo();
-  template <typename Conversion, typename std::enable_if<hasFieldInputInfo<Conversion>(), bool>::type = true>
-  static FieldInputInfo::Ptr getFieldInputInfo();
+  // Dispatch populating field input info from conversions.
+  template <typename Conversion,
+            typename ConfigT,
+            typename std::enable_if<!hasFieldInputInfo<Conversion>() || isConfig<ConfigT>(), bool>::type = true>
+  static void getFieldInputInfo(const std::string& field_name);
+
+  template <typename Conversion,
+            typename ConfigT,
+            typename std::enable_if<hasFieldInputInfo<Conversion>() && !isConfig<ConfigT>(), bool>::type = true>
+  static void getFieldInputInfo(const std::string& field_name);
 
   // Computes the default values for all fields in the meta data. This assumes that the meta data is already created,
   // and the meta data was created from ConfigT.

--- a/config_utilities/include/config_utilities/internal/visitor_impl.hpp
+++ b/config_utilities/include/config_utilities/internal/visitor_impl.hpp
@@ -252,7 +252,7 @@ void Visitor::visitField(std::vector<ConfigT>& config, const std::string& field_
   }
 
   if (visitor.mode == Visitor::Mode::kSet) {
-    const auto array_ns = visitor.name_space.empty() ? field_name : visitor.name_space + "/" + field_name;
+    const auto array_ns = joinNamespace(visitor.name_space, field_name);
     const auto subnode = lookupNamespace(visitor.data.data, array_ns);
     if (!subnode) {
       return;  // don't override the field if not present
@@ -330,7 +330,7 @@ void Visitor::visitField(OrderedMap<K, ConfigT>& config, const std::string& fiel
   }
 
   if (visitor.mode == Visitor::Mode::kSet) {
-    const auto map_ns = visitor.name_space.empty() ? field_name : visitor.name_space + "/" + field_name;
+    const auto map_ns = joinNamespace(visitor.name_space, field_name);
     const auto subnode = lookupNamespace(visitor.data.data, map_ns);
     if (!subnode) {
       return;  // don't override the field if not present


### PR DESCRIPTION
Fixes to how conversions are handled to deal with the issue I was showing you. Mostly straightforward though I had to change `getFieldInputInfo` slightly. I think my solution works but idk if you can see a cleaner way to handle it (there's some implicit state from how `visitField` gets called that is hard to reason about)