### PR TITLE
Fix/virtual config info

### DIFF
--- a/config_utilities/include/config_utilities/internal/meta_data.h
+++ b/config_utilities/include/config_utilities/internal/meta_data.h
@@ -151,7 +151,7 @@ struct MetaData {
   void performOnAll(const std::function<void(const MetaData&)>& func) const;
 
   // Utility function to get field info.
-  YAML::Node serializeFieldInfos() const;
+  YAML::Node serializeFieldInfos(const std::string& ns = "") const;
 
  private:
   void copyValues(const MetaData& other) {

--- a/config_utilities/src/meta_data.cpp
+++ b/config_utilities/src/meta_data.cpp
@@ -108,7 +108,10 @@ YAML::Node FieldInfo::serializeFieldInfos() const {
   return result;
 }
 
-YAML::Node MetaData::serializeFieldInfos() const {
+YAML::Node MetaData::serializeFieldInfos(const std::string& name_space) const {
+  auto ns = field_name.empty() ? name_space : joinNamespace(name_space, field_name);
+  auto curr_data = lookupNamespace(data, ns);
+
   YAML::Node result;
   // Log the config.
   result["type"] = "config";
@@ -116,21 +119,25 @@ YAML::Node MetaData::serializeFieldInfos() const {
   if (!field_name.empty()) {
     result["field_name"] = field_name;
   }
+
   if (is_virtual_config) {
     result["available_types"] = available_types;
     const auto type_name = Settings::instance().factory.type_param_name;
-    if (data[type_name]) {
-      result["name"] = data[type_name];
+    if (curr_data[type_name]) {
+      result["name"] = curr_data[type_name];
     } else {
       result["name"] = "Uninitialized Virtual Config";  // Reserved token for virtual configs that are not set.
     }
   }
+
   if (array_config_index >= 0) {
     result["array_index"] = array_config_index;
   }
+
   if (map_config_key) {
     result["map_config_key"] = map_config_key.value();
   }
+
   YAML::Node fields(YAML::NodeType::Sequence);
 
   // Parse the direct fields.
@@ -140,7 +147,7 @@ YAML::Node MetaData::serializeFieldInfos() const {
 
   // Parse the sub-configs.
   for (const MetaData& sub_data : sub_configs) {
-    fields.push_back(sub_data.serializeFieldInfos());
+    fields.push_back(sub_data.serializeFieldInfos(ns));
   }
 
   result["fields"] = fields;

--- a/config_utilities/src/meta_data.cpp
+++ b/config_utilities/src/meta_data.cpp
@@ -130,7 +130,7 @@ YAML::Node MetaData::serializeFieldInfos() const {
   if (map_config_key) {
     result["map_config_key"] = map_config_key.value();
   }
-  YAML::Node fields;
+  YAML::Node fields(YAML::NodeType::Sequence);
 
   // Parse the direct fields.
   for (const FieldInfo& info : field_infos) {

--- a/config_utilities/src/meta_data.cpp
+++ b/config_utilities/src/meta_data.cpp
@@ -118,8 +118,9 @@ YAML::Node MetaData::serializeFieldInfos() const {
   }
   if (is_virtual_config) {
     result["available_types"] = available_types;
-    if (data[field_name]) {
-      result["name"] = data[field_name][Settings::instance().factory.type_param_name];
+    const auto type_name = Settings::instance().factory.type_param_name;
+    if (data[type_name]) {
+      result["name"] = data[type_name];
     } else {
       result["name"] = "Uninitialized Virtual Config";  // Reserved token for virtual configs that are not set.
     }

--- a/config_utilities/test/include/config_utilities/test/utils.h
+++ b/config_utilities/test/include/config_utilities/test/utils.h
@@ -81,4 +81,19 @@ class TestLogger : public internal::Logger {
   inline static const auto registration_ = Registration<internal::Logger, TestLogger>("test_logger");
 };
 
+template <class BaseT, class DerivedT, class ConfigT, typename... Args>
+struct RegistrationGuard {
+  explicit RegistrationGuard(const std::string& type) : type(type) {
+    internal::ConfigFactory<BaseT>::template addEntry<ConfigT>(type);
+    internal::ObjectWithConfigFactory<BaseT, Args...>::template addEntry<DerivedT, ConfigT>(type);
+  }
+
+  ~RegistrationGuard() {
+    internal::ConfigFactory<BaseT>::template removeEntry<ConfigT>();
+    internal::ObjectWithConfigFactory<BaseT, Args...>::removeEntry(type);
+  }
+
+  std::string type;
+};
+
 }  // namespace config::test

--- a/config_utilities/test/include/config_utilities/test/utils.h
+++ b/config_utilities/test/include/config_utilities/test/utils.h
@@ -89,7 +89,7 @@ struct RegistrationGuard {
   }
 
   ~RegistrationGuard() {
-    internal::ConfigFactory<BaseT>::template removeEntry<ConfigT>();
+    internal::ConfigFactory<BaseT>::template removeEntry<ConfigT>(type);
     internal::ObjectWithConfigFactory<BaseT, Args...>::removeEntry(type);
   }
 

--- a/config_utilities/test/src/utils.cpp
+++ b/config_utilities/test/src/utils.cpp
@@ -63,7 +63,6 @@ bool expectEqualImpl(const YAML::Node& a, const YAML::Node& b, double epsilon = 
         return false;
       }
       for (size_t i = 0; i < a.size(); ++i) {
-        EXPECT_TRUE(expectEqualImpl(a[i], b[i], epsilon));
         if (!expectEqualImpl(a[i], b[i], epsilon)) {
           return false;
         }
@@ -80,7 +79,6 @@ bool expectEqualImpl(const YAML::Node& a, const YAML::Node& b, double epsilon = 
           ADD_FAILURE() << "Key '" << key << "' not found in b.";
           return false;
         }
-        EXPECT_TRUE(expectEqualImpl(kv_pair.second, b[key], epsilon));
         if (!expectEqualImpl(kv_pair.second, b[key], epsilon)) {
           return false;
         }

--- a/config_utilities/test/tests/field_input_info.cpp
+++ b/config_utilities/test/tests/field_input_info.cpp
@@ -258,17 +258,34 @@ TEST(FieldInputInfo, GetNestedVirtualInfo) {
   const auto reg_a = RegistrationGuard<Base, DerivedA, DerivedA::Config>("FieldA");
   const auto reg_b = RegistrationGuard<Base, DerivedB, DerivedB::Config>("FieldB");
 
-  config::VirtualConfig<Base> test;
-  const auto data = internal::Visitor::getInfo(test);
-  auto info = data.serializeFieldInfos();
-  const std::string expected = R"(
+  {  // uninitialized config
+    config::VirtualConfig<Base> test;
+    const auto data = internal::Visitor::getInfo(test);
+    auto info = data.serializeFieldInfos();
+    const std::string expected = R"(
 type: config
 name: Uninitialized Virtual Config
 available_types: [FieldA, FieldB]
 fields: []
 )";
 
-  expectEqual(info, YAML::Load(expected), 1e-6);
+    expectEqual(info, YAML::Load(expected), 1e-6);
+  }
+
+  {  // init config
+    config::VirtualConfig<Base> test{DerivedA::Config{}};
+    const auto data = internal::Visitor::getInfo(test);
+    auto info = data.serializeFieldInfos();
+    const std::string expected = R"(
+type: config
+name: FieldA
+available_types: [FieldA, FieldB]
+fields:
+  - {type: field, name: b, value: 1, default: 1, input_info: {type: float32}}
+)";
+
+    expectEqual(info, YAML::Load(expected), 1e-6);
+  }
 }
 
 }  // namespace config::test

--- a/config_utilities_ros/config_utilities_ros/gui/dynamic_config_gui.py
+++ b/config_utilities_ros/config_utilities_ros/gui/dynamic_config_gui.py
@@ -9,7 +9,9 @@ import logging
 
 FACTORY_TYPE_PAPRAM_NAME = "type"
 NS_SEP = "/"
-UNINITIALIZED_VIRTUAL_CONFIG_NAME = "Uninitialized Virtual Config" # Reserved token for empty virtual configs.
+UNINITIALIZED_VIRTUAL_CONFIG_NAME = (
+    "Uninitialized Virtual Config"  # Reserved token for empty virtual configs.
+)
 
 
 def to_yaml(data):
@@ -34,9 +36,7 @@ class DynamicConfigGUI:
         self.warnings = []
 
         # Config data containers
-        self._config_data = (
-            {}
-        )  # The underlying config data, this is the data that is received from the server.
+        self._config_data = {}  # The underlying config data, this is the data that is received from the server.
         self._fields = None  # The linearized fields to render in the GUI.
 
         # Server and key containers.
@@ -72,7 +72,7 @@ class DynamicConfigGUI:
         """
         self._is_setup = False
         if not debug:
-            log = logging.getLogger('werkzeug')
+            log = logging.getLogger("werkzeug")
             log.setLevel(logging.ERROR)
         if open_browser:
             # Open the browser to the GUI.
@@ -402,10 +402,8 @@ class DynamicConfigGUI:
                             id += f"{NS_SEP}{field['array_index']}"
                         elif "map_config_key" in field:
                             id += f"{NS_SEP}{field['map_config_key']}"
-                        val[FACTORY_TYPE_PAPRAM_NAME] = data[
-                                f"{id}-type"
-                            ]
-                        if field['name'] == UNINITIALIZED_VIRTUAL_CONFIG_NAME:
+                        val[FACTORY_TYPE_PAPRAM_NAME] = data[f"{id}-type"]
+                        if field["name"] == UNINITIALIZED_VIRTUAL_CONFIG_NAME:
                             # Special case for the not set config.
                             has_subfields = False
                     if "array_index" in field:
@@ -438,7 +436,9 @@ class DynamicConfigGUI:
                         field["map_config_key"] = new_key
                     else:
                         # Parse all fields in a regular config.
-                        values[field["field_name"]] = parse_rec(field, new_prefix, val) if has_subfields else val
+                        values[field["field_name"]] = (
+                            parse_rec(field, new_prefix, val) if has_subfields else val
+                        )
                 else:
                     raise ValueError(f"Unknown field type: {field['type']}")
             return values


### PR DESCRIPTION
@Schmluk figured out this issue with dynamic configs that we were running into (the way you were exporting the type only worked for virtual configs that were fields of the top level config). Solution is to track the current namespace of the subconfig field you're exporting.

Also adds some tests (and additional test infrastructure) and cleans up exporting a config with no fields. I accidentally ran ruff on the gui python file, lmk if you want me to revert those changes