### PR TITLE
update virtual config type tracking and cleanup

### DIFF
--- a/config_utilities/include/config_utilities/internal/meta_data.h
+++ b/config_utilities/include/config_utilities/internal/meta_data.h
@@ -49,6 +49,9 @@
 
 namespace config::internal {
 
+// Reserved token for virtual configs that are not set.
+inline const std::string kUninitializedVirtualConfigType = "Uninitialized Virtual Config";
+
 /**
  * @brief Struct that holds additional information about fields for printing.
  */
@@ -113,8 +116,9 @@ struct MetaData {
   // Name of the field if the data is a sub-config.
   std::string field_name;
 
-  // Whether the data stored belongs to a virtual config.
-  bool is_virtual_config = false;
+  // If the config is a virtual config, this is the type of the virtual config. If it is not set, the type will be the
+  // uninitialized virtual config string.
+  std::string virtual_config_type;
 
   // If the config is a virtual config, the own input info stores the available types.
   std::vector<std::string> available_types;
@@ -150,15 +154,19 @@ struct MetaData {
   void performOnAll(const std::function<void(MetaData&)>& func);
   void performOnAll(const std::function<void(const MetaData&)>& func) const;
 
+  // Check whether this is a virtual config.
+  bool isVirtualConfig() const { return !virtual_config_type.empty(); }
+
   // Utility function to get field info.
-  YAML::Node serializeFieldInfos(const std::string& ns = "") const;
+  YAML::Node serializeFieldInfos() const;
 
  private:
   void copyValues(const MetaData& other) {
     name = other.name;
-    is_virtual_config = other.is_virtual_config;
     data = YAML::Clone(other.data);
     field_infos = other.field_infos;
+    checks.clear();
+    errors.clear();
     for (const auto& check : other.checks) {
       checks.emplace_back(check->clone());
     }
@@ -169,6 +177,7 @@ struct MetaData {
     sub_configs = other.sub_configs;
     array_config_index = other.array_config_index;
     map_config_key = other.map_config_key;
+    virtual_config_type = other.virtual_config_type;
     available_types = other.available_types;
   }
 };

--- a/config_utilities/include/config_utilities/virtual_config.h
+++ b/config_utilities/include/config_utilities/virtual_config.h
@@ -43,10 +43,6 @@
 #include "config_utilities/factory.h"
 #include "config_utilities/traits.h"
 
-namespace config::internal {
-inline static const std::string kUninitializedVirtualConfigType = "Uninitialized Virtual Config";
-}
-
 namespace config {
 
 /**
@@ -152,7 +148,7 @@ class VirtualConfig {
   /**
    * @brief Get the string-identifier-type of the config stored in the virtual config.
    */
-  std::string getType() const { return config_ ? config_->type : "Uninitialized"; }
+  std::string getType() const { return config_ ? config_->type : internal::kUninitializedVirtualConfigType; }
 
   /**
    * @brief Get the underlying config that this holds, if set

--- a/config_utilities/src/asl_formatter.cpp
+++ b/config_utilities/src/asl_formatter.cpp
@@ -238,7 +238,7 @@ std::string AslFormatter::formatSubconfig(const MetaData& data, size_t indent) c
   if (settings.show_subconfig_types) {
     header += " [" + resolveConfigName(data) + "]";
   }
-  if (settings.show_defaults && !data.is_virtual_config) {
+  if (settings.show_defaults && !data.isVirtualConfig()) {
     bool is_default = true;
     for (const FieldInfo& info : data.field_infos) {
       if (!info.isDefault()) {
@@ -250,7 +250,7 @@ std::string AslFormatter::formatSubconfig(const MetaData& data, size_t indent) c
       header += " (default)";
     }
   }
-  if (resolveConfigName(data) != "Uninitialized Virtual Config") {
+  if (resolveConfigName(data) != kUninitializedVirtualConfigType) {
     header += ":";
   }
   header += "\n";
@@ -343,13 +343,14 @@ std::string AslFormatter::formatField(const FieldInfo& info, size_t indent) cons
 
 std::string AslFormatter::resolveConfigName(const MetaData& data) const {
   if (data.name.empty()) {
-    if (data.is_virtual_config) {
+    if (data.isVirtualConfig()) {
+      // NOTE(lschmid): Here we use the human readable name of the virtual config type if the token were to get changed.
       return "Uninitialized Virtual Config";
     } else {
       return "Unnamed Config";
     }
   } else {
-    if (data.is_virtual_config && Settings::instance().printing.show_virtual_configs) {
+    if (data.isVirtualConfig() && Settings::instance().printing.show_virtual_configs) {
       return "Virtual Config: " + data.name;
     } else {
       return data.name;

--- a/config_utilities/src/meta_data.cpp
+++ b/config_utilities/src/meta_data.cpp
@@ -108,10 +108,7 @@ YAML::Node FieldInfo::serializeFieldInfos() const {
   return result;
 }
 
-YAML::Node MetaData::serializeFieldInfos(const std::string& name_space) const {
-  auto ns = field_name.empty() ? name_space : joinNamespace(name_space, field_name);
-  auto curr_data = lookupNamespace(data, ns);
-
+YAML::Node MetaData::serializeFieldInfos() const {
   YAML::Node result;
   // Log the config.
   result["type"] = "config";
@@ -120,14 +117,10 @@ YAML::Node MetaData::serializeFieldInfos(const std::string& name_space) const {
     result["field_name"] = field_name;
   }
 
-  if (is_virtual_config) {
+  if (isVirtualConfig()) {
+    // This is a virtual config: Use the virtual config type as the name.
     result["available_types"] = available_types;
-    const auto type_name = Settings::instance().factory.type_param_name;
-    if (curr_data[type_name]) {
-      result["name"] = curr_data[type_name];
-    } else {
-      result["name"] = "Uninitialized Virtual Config";  // Reserved token for virtual configs that are not set.
-    }
+    result["name"] = virtual_config_type;
   }
 
   if (array_config_index >= 0) {
@@ -147,7 +140,7 @@ YAML::Node MetaData::serializeFieldInfos(const std::string& name_space) const {
 
   // Parse the sub-configs.
   for (const MetaData& sub_data : sub_configs) {
-    fields.push_back(sub_data.serializeFieldInfos(ns));
+    fields.push_back(sub_data.serializeFieldInfos());
   }
 
   result["fields"] = fields;

--- a/config_utilities/src/visitor.cpp
+++ b/config_utilities/src/visitor.cpp
@@ -86,7 +86,7 @@ std::optional<YAML::Node> Visitor::visitVirtualConfig(bool is_set,
                                                       const std::string& type,
                                                       const std::string& base_type) {
   Visitor& visitor = Visitor::instance();
-  visitor.data.is_virtual_config = true;
+  visitor.data.virtual_config_type = type;
 
   // Treat the validity of virtual configs as checks.
   if (visitor.mode == Visitor::Mode::kCheck) {
@@ -110,7 +110,7 @@ std::optional<YAML::Node> Visitor::visitVirtualConfig(bool is_set,
   if (visitor.mode == internal::Visitor::Mode::kGetInfo) {
     visitor.data.available_types = ModuleRegistry::getRegisteredConfigTypes(base_type);
     if (is_optional) {
-      visitor.data.available_types.push_back("Uninitialized Virtual Config");
+      visitor.data.available_types.push_back(kUninitializedVirtualConfigType);
     }
   }
 

--- a/config_utilities_ros/config_utilities_ros/gui/dynamic_config_gui.py
+++ b/config_utilities_ros/config_utilities_ros/gui/dynamic_config_gui.py
@@ -335,7 +335,7 @@ class DynamicConfigGUI:
                     if "available_types" in field:
                         # Virtual configs
                         conf_data["available_types"] = field["available_types"]
-                        if field["name"] == "Uninitialized Virtual Config":
+                        if field["name"] == UNINITIALIZED_VIRTUAL_CONFIG_NAME:
                             # Special case for the not set config.
                             has_subfields = False
                     if "array_index" in field:


### PR DESCRIPTION
Final updates before sending ros2 conf utils live:
- Implements more transparent and fail-proof virtual config type tracking.
- Clean up some general handling of uninitialized virtual configs
- utests pass (those came in handy already!)
- Tested on a demo with nested configs (up to 6 nests deep, looks good)