### PR TITLE
add missing rosdeps for minimal install

### DIFF
--- a/config_utilities/package.xml
+++ b/config_utilities/package.xml
@@ -14,6 +14,8 @@
 
   <buildtool_depend>cmake</buildtool_depend>
   <depend>yaml-cpp</depend>
+  <depend>libboost-filesystem-dev</depend>
+  <depend>libboost-system-dev</depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
Fixes the fact that boost isn't installed with a barebones ros install