### PR TITLE
use node interfaces instead of pure node

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,10 +50,10 @@ The following tutorials will guide you through functionalities of `config_utilit
     - [Debugging](External.md#debugging)
 
 9. [**Dynamic Configs**](Dynamic_Configs.md)
-    - [Declaring a dynamic config](Dynamix_Configs.md#declaring-a-dynamic-config)
-    - [Dynamic Config Callbacks](Dynamix_Configs.md#dynamic-config-callbacks)
-    - [Setting Dynamic Configs](Dynamix_Configs.md#setting-dynamic-configs)
-    - [Custom Dynamic Config Servers](Dynamix_Configs.md#custom-dynamic-config-servers)
+    - [Declaring a dynamic config](Dynamic_Configs.md#declaring-a-dynamic-config)
+    - [Dynamic Config Callbacks](Dynamic_Configs.md#dynamic-config-callbacks)
+    - [Setting Dynamic Configs](Dynamic_Configs.md#setting-dynamic-configs)
+    - [Custom Dynamic Config Servers](Dynamic_Configs.md#custom-dynamic-config-servers)
 
 10. [**Varia**](Varia.md)
     - [Settings](Varia.md#settings)


### PR DESCRIPTION
@Schmluk ran into a case where I wanted the dynamic configs but didn't have a pointer to the underlying node, so refactored the server to use the node interfaces. This works on ROS2 Humble (unlike Ianvs) and hopefully also Jazzy (which I'm going to test soon)