### PR TITLE
fix/field info deduction for conversions

### DIFF
--- a/config_utilities/include/config_utilities/internal/visitor.h
+++ b/config_utilities/include/config_utilities/internal/visitor.h
@@ -169,13 +169,15 @@ struct Visitor {
   // Dispatch populating field input info from conversions.
   template <typename Conversion,
             typename ConfigT,
+            typename IntermediateT,
             typename std::enable_if<!hasFieldInputInfo<Conversion>() || isConfig<ConfigT>(), bool>::type = true>
-  static void getFieldInputInfo(const std::string& field_name);
+  static void getFieldInputInfo(const IntermediateT& intermediate, const std::string& field_name);
 
   template <typename Conversion,
             typename ConfigT,
+            typename IntermediateT,
             typename std::enable_if<hasFieldInputInfo<Conversion>() && !isConfig<ConfigT>(), bool>::type = true>
-  static void getFieldInputInfo(const std::string& field_name);
+  static void getFieldInputInfo(const IntermediateT& intermediate, const std::string& field_name);
 
   // Computes the default values for all fields in the meta data. This assumes that the meta data is already created,
   // and the meta data was created from ConfigT.

--- a/config_utilities/test/tests/conversions.cpp
+++ b/config_utilities/test/tests/conversions.cpp
@@ -243,8 +243,10 @@ TEST(Conversions, FieldInputInfo) {
   ConversionStruct without_info;
   data = internal::Visitor::getInfo(without_info);
   EXPECT_EQ(data.field_infos.size(), 2);
-  EXPECT_FALSE(data.field_infos[0].input_info);
-  EXPECT_FALSE(data.field_infos[1].input_info);
+  EXPECT_TRUE(data.field_infos[0].input_info);
+  EXPECT_TRUE(data.field_infos[1].input_info);
+  EXPECT_EQ(data.field_infos[0].input_info->type, internal::FieldInputInfo::Type::kInt);     // num_threads
+  EXPECT_EQ(data.field_infos[1].input_info->type, internal::FieldInputInfo::Type::kString);  // some_character
 }
 
 TEST(Conversions, ConversionDeclareConfigDispatch) {

--- a/config_utilities_ros/config_utilities_ros/gui/dynamic_config_gui.py
+++ b/config_utilities_ros/config_utilities_ros/gui/dynamic_config_gui.py
@@ -314,6 +314,10 @@ class DynamicConfigGUI:
             prefix_str = "".join([f"{p}{NS_SEP}" for p in prefix])
             for field in config["fields"]:
                 if field["type"] == "field":
+                    # Default the input info to just strings if no details are present.
+                    if "input_info" not in field:
+                        field["input_info"] = {"type": "yaml"}
+
                     # Data for each field (leaves of the config).
                     field["id"] = f"{prefix_str}{field['name']}"
                     field["indent"] = indent


### PR DESCRIPTION
Found a rare corner case: Fields with a `Conversion` that did not specialize a `getFieldInputInfo()` function did not have any input info, which broke the dynamic config GUI.
- Now defaults to the intermediate type as input type if not specialized.
- Also catch on the GUI side for more graceful failures or catches (if there were other such corner cases in the future)
- Updated utests