### PR TITLE
Fix/opt deps

### DIFF
--- a/config_utilities/cmake/config_utilitiesConfig.cmake.in
+++ b/config_utilities/cmake/config_utilitiesConfig.cmake.in
@@ -5,8 +5,13 @@ get_filename_component(config_utilities_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}"
 include(CMakeFindDependencyMacro)
 
 find_dependency(yaml-cpp REQUIRED)
-find_dependency(Eigen3 QUIET)
-find_dependency(glog QUIET)
+if (@Eigen3_FOUND@)
+  find_dependency(Eigen3 QUIET)
+endif()
+
+if (@glog_FOUND@)
+  find_dependency(glog QUIET)
+endif()
 
 if(NOT TARGET config_utilities::config_utilities)
   include("${config_utilities_CMAKE_DIR}/config_utilitiesTargets.cmake")

--- a/config_utilities/cmake/config_utilitiesConfig.cmake.in
+++ b/config_utilities/cmake/config_utilitiesConfig.cmake.in
@@ -5,12 +5,12 @@ get_filename_component(config_utilities_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}"
 include(CMakeFindDependencyMacro)
 
 find_dependency(yaml-cpp REQUIRED)
-if (@Eigen3_FOUND@)
-  find_dependency(Eigen3 QUIET)
+if (@Eigen3_FOUND@)  # expanded from Eigen3_FOUND during build time
+  find_dependency(Eigen3)
 endif()
 
-if (@glog_FOUND@)
-  find_dependency(glog QUIET)
+if (@glog_FOUND@)  # expanded from glog_FOUND during build time
+  find_dependency(glog)
 endif()
 
 if(NOT TARGET config_utilities::config_utilities)


### PR DESCRIPTION
@Schmluk Didn't actually read the docs for `find_dependency` carefully and didn't realize that any argument you pass to the `find_package(config_utilities)` call gets passed to the underlying `find_dependency` calls, which will require the dependency even if they were optional before