### PR TITLE
add alternate initContext method

### DIFF
--- a/config_utilities/include/config_utilities/parsing/context.h
+++ b/config_utilities/include/config_utilities/parsing/context.h
@@ -38,6 +38,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "config_utilities/internal/config_context.h"
 
@@ -50,6 +51,12 @@ namespace config {
  * @param remove_arguments Remove parsed command line arguments.
  */
 void initContext(int& argc, char* argv[], bool remove_arguments = true);
+
+/**
+ * @brief Initialize global config context from the command line
+ * @param args Command line arguments
+ */
+void initContext(const std::vector<std::string>& args);
 
 /**
  * @brief Aggregate YAML node into global context

--- a/config_utilities/src/context.cpp
+++ b/config_utilities/src/context.cpp
@@ -37,6 +37,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "config_utilities/internal/config_context.h"
 #include "config_utilities/internal/introspection.h"
@@ -47,6 +48,11 @@ namespace config {
 
 void initContext(int& argc, char* argv[], bool remove_arguments) {
   const auto node = internal::loadFromArguments(argc, argv, remove_arguments);
+  internal::Context::update(node, "", internal::MergeMode::APPEND);
+}
+
+void initContext(const std::vector<std::string>& args) {
+  const auto node = internal::loadFromArguments(args);
   internal::Context::update(node, "", internal::MergeMode::APPEND);
 }
 


### PR DESCRIPTION
Adds overload for initializing config context that matches existing command-line parsing overload